### PR TITLE
Add dark mode support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ _site
 .jekyll-cache
 .jekyll-metadata
 vendor
+.bundle

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -1,0 +1,26 @@
+---
+---
+
+@import "minima";
+
+/* Dark mode styles */
+@media (prefers-color-scheme: dark) {
+  body {
+    background-color: #121212;
+    color: #e0e0e0;
+  }
+
+  a {
+    color: #82aaff;
+  }
+
+  .site-header,
+  .site-footer {
+    background-color: #1f1f1f;
+    border-color: #333;
+  }
+
+  .highlight {
+    background: #2d2d2d;
+  }
+}


### PR DESCRIPTION
## Summary
- add dark mode overrides in `assets/main.scss`
- ignore `.bundle` folder

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_6858a7877ce08321996d09b6e859512c