### PR TITLE
Fix dark mode styles

### DIFF
--- a/assets/_base16-dark.scss
+++ b/assets/_base16-dark.scss
@@ -1,0 +1,91 @@
+.highlight table td { padding: 5px; }
+.highlight table pre { margin: 0; }
+.highlight, .highlight .w {
+  color: #93a1a1;
+  background-color: #002b36;
+}
+.highlight .err {
+  color: #002b36;
+  background-color: #dc322f;
+}
+.highlight .c, .highlight .ch, .highlight .cd, .highlight .cm, .highlight .cpf, .highlight .c1, .highlight .cs {
+  color: #657b83;
+}
+.highlight .cp {
+  color: #b58900;
+}
+.highlight .nt {
+  color: #b58900;
+}
+.highlight .o, .highlight .ow {
+  color: #93a1a1;
+}
+.highlight .p, .highlight .pi {
+  color: #93a1a1;
+}
+.highlight .gi {
+  color: #859900;
+}
+.highlight .gd {
+  color: #dc322f;
+}
+.highlight .gh {
+  color: #268bd2;
+  background-color: #002b36;
+  font-weight: bold;
+}
+.highlight .ge {
+  font-style: italic;
+}
+.highlight .ges {
+  font-weight: bold;
+  font-style: italic;
+}
+.highlight .gs {
+  font-weight: bold;
+}
+.highlight .k, .highlight .kn, .highlight .kp, .highlight .kr, .highlight .kv {
+  color: #6c71c4;
+}
+.highlight .kc {
+  color: #cb4b16;
+}
+.highlight .kt {
+  color: #cb4b16;
+}
+.highlight .kd {
+  color: #cb4b16;
+}
+.highlight .s, .highlight .sb, .highlight .sc, .highlight .dl, .highlight .sd, .highlight .s2, .highlight .sh, .highlight .sx, .highlight .s1 {
+  color: #859900;
+}
+.highlight .sa {
+  color: #6c71c4;
+}
+.highlight .sr {
+  color: #2aa198;
+}
+.highlight .si {
+  color: #d33682;
+}
+.highlight .se {
+  color: #d33682;
+}
+.highlight .nn {
+  color: #b58900;
+}
+.highlight .nc {
+  color: #b58900;
+}
+.highlight .no {
+  color: #b58900;
+}
+.highlight .na {
+  color: #268bd2;
+}
+.highlight .m, .highlight .mb, .highlight .mf, .highlight .mh, .highlight .mi, .highlight .il, .highlight .mo, .highlight .mx {
+  color: #859900;
+}
+.highlight .ss {
+  color: #859900;
+}

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -12,6 +12,18 @@
 
   a {
     color: #82aaff;
+    &:hover {
+      color: lighten(#82aaff, 10%);
+    }
+  }
+
+  .site-title,
+  .site-title:visited {
+    color: #e0e0e0;
+  }
+
+  .site-nav .page-link {
+    color: #e0e0e0;
   }
 
   .site-header,
@@ -22,5 +34,14 @@
 
   .highlight {
     background: #2d2d2d;
+    color: #e0e0e0;
   }
+
+  pre,
+  code {
+    background-color: #2d2d2d;
+    color: #e0e0e0;
+  }
+
+  @import "base16-dark";
 }


### PR DESCRIPTION
## Summary
- improve dark mode readability
  - lighten header and nav text
  - lighten link hover color
  - style code snippets for dark theme
  - include rouge base16 dark theme

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_6859c29551b48321bc6029c9f7d42127