### PR TITLE
Add dark mode syntax themes

### DIFF
--- a/_sass/_dracula.scss
+++ b/_sass/_dracula.scss
@@ -1,0 +1,91 @@
+.highlight table td { padding: 5px; }
+.highlight table pre { margin: 0; }
+.highlight, .highlight .w {
+  color: #e9e9f4;
+  background-color: #282936;
+}
+.highlight .err {
+  color: #282936;
+  background-color: #ea51b2;
+}
+.highlight .c, .highlight .ch, .highlight .cd, .highlight .cm, .highlight .cpf, .highlight .c1, .highlight .cs {
+  color: #626483;
+}
+.highlight .cp {
+  color: #00f769;
+}
+.highlight .nt {
+  color: #00f769;
+}
+.highlight .o, .highlight .ow {
+  color: #e9e9f4;
+}
+.highlight .p, .highlight .pi {
+  color: #e9e9f4;
+}
+.highlight .gi {
+  color: #ebff87;
+}
+.highlight .gd {
+  color: #ea51b2;
+}
+.highlight .gh {
+  color: #62d6e8;
+  background-color: #282936;
+  font-weight: bold;
+}
+.highlight .ge {
+  font-style: italic;
+}
+.highlight .ges {
+  font-weight: bold;
+  font-style: italic;
+}
+.highlight .gs {
+  font-weight: bold;
+}
+.highlight .k, .highlight .kn, .highlight .kp, .highlight .kr, .highlight .kv {
+  color: #b45bcf;
+}
+.highlight .kc {
+  color: #b45bcf;
+}
+.highlight .kt {
+  color: #b45bcf;
+}
+.highlight .kd {
+  color: #b45bcf;
+}
+.highlight .s, .highlight .sb, .highlight .sc, .highlight .dl, .highlight .sd, .highlight .s2, .highlight .sh, .highlight .sx, .highlight .s1 {
+  color: #ebff87;
+}
+.highlight .sa {
+  color: #b45bcf;
+}
+.highlight .sr {
+  color: #a1efe4;
+}
+.highlight .si {
+  color: #00f769;
+}
+.highlight .se {
+  color: #00f769;
+}
+.highlight .nn {
+  color: #00f769;
+}
+.highlight .nc {
+  color: #00f769;
+}
+.highlight .no {
+  color: #00f769;
+}
+.highlight .na {
+  color: #62d6e8;
+}
+.highlight .m, .highlight .mb, .highlight .mf, .highlight .mh, .highlight .mi, .highlight .il, .highlight .mo, .highlight .mx {
+  color: #ebff87;
+}
+.highlight .ss {
+  color: #ebff87;
+}

--- a/_sass/_gruvbox-dark.scss
+++ b/_sass/_gruvbox-dark.scss
@@ -1,0 +1,91 @@
+.highlight table td { padding: 5px; }
+.highlight table pre { margin: 0; }
+.highlight, .highlight .w {
+  color: #d5c4a1;
+  background-color: #1d2021;
+}
+.highlight .err {
+  color: #1d2021;
+  background-color: #fb4934;
+}
+.highlight .c, .highlight .ch, .highlight .cd, .highlight .cm, .highlight .cpf, .highlight .c1, .highlight .cs {
+  color: #665c54;
+}
+.highlight .cp {
+  color: #fabd2f;
+}
+.highlight .nt {
+  color: #fabd2f;
+}
+.highlight .o, .highlight .ow {
+  color: #d5c4a1;
+}
+.highlight .p, .highlight .pi {
+  color: #d5c4a1;
+}
+.highlight .gi {
+  color: #b8bb26;
+}
+.highlight .gd {
+  color: #fb4934;
+}
+.highlight .gh {
+  color: #83a598;
+  background-color: #1d2021;
+  font-weight: bold;
+}
+.highlight .ge {
+  font-style: italic;
+}
+.highlight .ges {
+  font-weight: bold;
+  font-style: italic;
+}
+.highlight .gs {
+  font-weight: bold;
+}
+.highlight .k, .highlight .kn, .highlight .kp, .highlight .kr, .highlight .kv {
+  color: #d3869b;
+}
+.highlight .kc {
+  color: #fe8019;
+}
+.highlight .kt {
+  color: #fe8019;
+}
+.highlight .kd {
+  color: #fe8019;
+}
+.highlight .s, .highlight .sb, .highlight .sc, .highlight .dl, .highlight .sd, .highlight .s2, .highlight .sh, .highlight .sx, .highlight .s1 {
+  color: #b8bb26;
+}
+.highlight .sa {
+  color: #d3869b;
+}
+.highlight .sr {
+  color: #8ec07c;
+}
+.highlight .si {
+  color: #d65d0e;
+}
+.highlight .se {
+  color: #d65d0e;
+}
+.highlight .nn {
+  color: #fabd2f;
+}
+.highlight .nc {
+  color: #fabd2f;
+}
+.highlight .no {
+  color: #fabd2f;
+}
+.highlight .na {
+  color: #83a598;
+}
+.highlight .m, .highlight .mb, .highlight .mf, .highlight .mh, .highlight .mi, .highlight .il, .highlight .mo, .highlight .mx {
+  color: #b8bb26;
+}
+.highlight .ss {
+  color: #b8bb26;
+}

--- a/_sass/_monokai.scss
+++ b/_sass/_monokai.scss
@@ -1,0 +1,91 @@
+.highlight table td { padding: 5px; }
+.highlight table pre { margin: 0; }
+.highlight, .highlight .w {
+  color: #f8f8f2;
+  background-color: #272822;
+}
+.highlight .err {
+  color: #272822;
+  background-color: #f92672;
+}
+.highlight .c, .highlight .ch, .highlight .cd, .highlight .cm, .highlight .cpf, .highlight .c1, .highlight .cs {
+  color: #75715e;
+}
+.highlight .cp {
+  color: #f4bf75;
+}
+.highlight .nt {
+  color: #f4bf75;
+}
+.highlight .o, .highlight .ow {
+  color: #f8f8f2;
+}
+.highlight .p, .highlight .pi {
+  color: #f8f8f2;
+}
+.highlight .gi {
+  color: #a6e22e;
+}
+.highlight .gd {
+  color: #f92672;
+}
+.highlight .gh {
+  color: #66d9ef;
+  background-color: #272822;
+  font-weight: bold;
+}
+.highlight .ge {
+  font-style: italic;
+}
+.highlight .ges {
+  font-weight: bold;
+  font-style: italic;
+}
+.highlight .gs {
+  font-weight: bold;
+}
+.highlight .k, .highlight .kn, .highlight .kp, .highlight .kr, .highlight .kv {
+  color: #ae81ff;
+}
+.highlight .kc {
+  color: #fd971f;
+}
+.highlight .kt {
+  color: #fd971f;
+}
+.highlight .kd {
+  color: #fd971f;
+}
+.highlight .s, .highlight .sb, .highlight .sc, .highlight .dl, .highlight .sd, .highlight .s2, .highlight .sh, .highlight .sx, .highlight .s1 {
+  color: #a6e22e;
+}
+.highlight .sa {
+  color: #ae81ff;
+}
+.highlight .sr {
+  color: #a1efe4;
+}
+.highlight .si {
+  color: #cc6633;
+}
+.highlight .se {
+  color: #cc6633;
+}
+.highlight .nn {
+  color: #f4bf75;
+}
+.highlight .nc {
+  color: #f4bf75;
+}
+.highlight .no {
+  color: #f4bf75;
+}
+.highlight .na {
+  color: #66d9ef;
+}
+.highlight .m, .highlight .mb, .highlight .mf, .highlight .mh, .highlight .mi, .highlight .il, .highlight .mo, .highlight .mx {
+  color: #a6e22e;
+}
+.highlight .ss {
+  color: #a6e22e;
+}

--- a/_sass/_nord.scss
+++ b/_sass/_nord.scss
@@ -1,0 +1,91 @@
+.highlight table td { padding: 5px; }
+.highlight table pre { margin: 0; }
+.highlight, .highlight .w {
+  color: #E5E9F0;
+  background-color: #2E3440;
+}
+.highlight .err {
+  color: #2E3440;
+  background-color: #BF616A;
+}
+.highlight .c, .highlight .ch, .highlight .cd, .highlight .cm, .highlight .cpf, .highlight .c1, .highlight .cs {
+  color: #4C566A;
+}
+.highlight .cp {
+  color: #EBCB8B;
+}
+.highlight .nt {
+  color: #EBCB8B;
+}
+.highlight .o, .highlight .ow {
+  color: #E5E9F0;
+}
+.highlight .p, .highlight .pi {
+  color: #E5E9F0;
+}
+.highlight .gi {
+  color: #A3BE8C;
+}
+.highlight .gd {
+  color: #BF616A;
+}
+.highlight .gh {
+  color: #81A1C1;
+  background-color: #2E3440;
+  font-weight: bold;
+}
+.highlight .ge {
+  font-style: italic;
+}
+.highlight .ges {
+  font-weight: bold;
+  font-style: italic;
+}
+.highlight .gs {
+  font-weight: bold;
+}
+.highlight .k, .highlight .kn, .highlight .kp, .highlight .kr, .highlight .kv {
+  color: #B48EAD;
+}
+.highlight .kc {
+  color: #D08770;
+}
+.highlight .kt {
+  color: #D08770;
+}
+.highlight .kd {
+  color: #D08770;
+}
+.highlight .s, .highlight .sb, .highlight .sc, .highlight .dl, .highlight .sd, .highlight .s2, .highlight .sh, .highlight .sx, .highlight .s1 {
+  color: #A3BE8C;
+}
+.highlight .sa {
+  color: #B48EAD;
+}
+.highlight .sr {
+  color: #88C0D0;
+}
+.highlight .si {
+  color: #5E81AC;
+}
+.highlight .se {
+  color: #5E81AC;
+}
+.highlight .nn {
+  color: #EBCB8B;
+}
+.highlight .nc {
+  color: #EBCB8B;
+}
+.highlight .no {
+  color: #EBCB8B;
+}
+.highlight .na {
+  color: #81A1C1;
+}
+.highlight .m, .highlight .mb, .highlight .mf, .highlight .mh, .highlight .mi, .highlight .il, .highlight .mo, .highlight .mx {
+  color: #A3BE8C;
+}
+.highlight .ss {
+  color: #A3BE8C;
+}

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -42,6 +42,6 @@
     background-color: #2d2d2d;
     color: #e0e0e0;
   }
-
-  @import "base16-dark";
+  $dark-syntax-theme: "base16-dark"; // options: base16-dark, dracula, monokai, nord, gruvbox-dark
+  @import "#{$dark-syntax-theme}";
 }


### PR DESCRIPTION
## Summary
- add four syntax highlight themes: Dracula, Monokai, Nord, Gruvbox Dark
- make the active dark theme configurable via `$dark-syntax-theme`

## Testing
- `bundle exec jekyll build` *(fails: ruby 3.2.2 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685a139a47988321a7edbbb6561f0e7a