### PR TITLE
Add simple one-pager template

### DIFF
--- a/_layouts/onepager.html
+++ b/_layouts/onepager.html
@@ -1,0 +1,54 @@
+---
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>{{ site.title }}</title>
+  <link rel="stylesheet" href="{{ '/assets/main.css' | relative_url }}" />
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+      margin: 0;
+      padding: 0;
+      line-height: 1.6;
+    }
+    .hero {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      min-height: 60vh;
+      text-align: center;
+      background: #fafafa;
+    }
+    .hero h1 {
+      font-size: 3rem;
+      margin: 0;
+    }
+    .section {
+      max-width: 800px;
+      margin: 2rem auto;
+      padding: 0 1rem;
+    }
+    .footer {
+      text-align: center;
+      padding: 2rem 0;
+      background: #fafafa;
+    }
+  </style>
+</head>
+<body>
+  <div class="hero">
+    <h1>{{ site.title }}</h1>
+    <p>{{ site.description }}</p>
+  </div>
+  <div class="section">
+    {{ content }}
+  </div>
+  <div class="footer">
+    &copy; {{ site.time | date: '%Y' }} {{ site.title }}
+  </div>
+</body>
+</html>

--- a/_layouts/onepager.html
+++ b/_layouts/onepager.html
@@ -7,47 +7,16 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>{{ site.title }}</title>
   <link rel="stylesheet" href="{{ '/assets/main.css' | relative_url }}" />
-  <style>
-    body {
-      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-      margin: 0;
-      padding: 0;
-      line-height: 1.6;
-    }
-    .hero {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      justify-content: center;
-      min-height: 60vh;
-      text-align: center;
-      background: #fafafa;
-    }
-    .hero h1 {
-      font-size: 3rem;
-      margin: 0;
-    }
-    .section {
-      max-width: 800px;
-      margin: 2rem auto;
-      padding: 0 1rem;
-    }
-    .footer {
-      text-align: center;
-      padding: 2rem 0;
-      background: #fafafa;
-    }
-  </style>
 </head>
-<body>
-  <div class="hero">
+<body class="onepager-body">
+  <div class="onepager-hero">
     <h1>{{ site.title }}</h1>
     <p>{{ site.description }}</p>
   </div>
-  <div class="section">
+  <div class="onepager-section">
     {{ content }}
   </div>
-  <div class="footer">
+  <div class="onepager-footer">
     &copy; {{ site.time | date: '%Y' }} {{ site.title }}
   </div>
 </body>

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -3,6 +3,42 @@
 
 @import "minima";
 
+/* Onepager layout styles */
+.onepager-body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    "Helvetica Neue", Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+  line-height: 1.6;
+}
+
+.onepager-hero {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 60vh;
+  text-align: center;
+  background: #fafafa;
+}
+
+.onepager-hero h1 {
+  font-size: 3rem;
+  margin: 0;
+}
+
+.onepager-section {
+  max-width: 800px;
+  margin: 2rem auto;
+  padding: 0 1rem;
+}
+
+.onepager-footer {
+  text-align: center;
+  padding: 2rem 0;
+  background: #fafafa;
+}
+
 /* Dark mode styles */
 @media (prefers-color-scheme: dark) {
   body {
@@ -44,6 +80,11 @@
   .highlight {
     background: #2d2d2d;
     color: #e0e0e0;
+  }
+
+  .onepager-hero,
+  .onepager-footer {
+    background: #1f1f1f;
   }
 
   pre,

--- a/onepager.markdown
+++ b/onepager.markdown
@@ -1,0 +1,7 @@
+---
+layout: onepager
+title: One Pager Example
+permalink: /onepager/
+---
+
+Welcome! This is a simple one-page layout. Replace this text with your own content.


### PR DESCRIPTION
## Summary
- add a custom `onepager` layout with basic styling
- include an example page that uses the new layout

## Testing
- `bundle exec jekyll build` *(fails: rbenv version `3.2.2` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685c44be86c8832195743d6776acb12e