### PR TITLE
🎨 Palette: Improve mobile navigation keyboard accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -11,3 +11,7 @@
 ## 2026-02-11 - Print Styles for Content
 **Learning:** Users still print articles (or save as PDF). Default web styles often clutter the page with navigation, footers, and interactive elements like progress bars, wasting ink and distracting from the content.
 **Action:** Add a simple `@media print` stylesheet that hides `.site-header`, `.site-footer`, and interactive widgets, while ensuring high contrast (black on white) and expanding external links for offline reference.
+
+## 2026-05-10 - Mobile Navigation Accessibility
+**Learning:** Overriding default theme styles that use `display: none` for custom toggle patterns (like the "checkbox hack" used for mobile navigation) is necessary for keyboard accessibility. Elements hidden with `display: none` are removed from the accessibility tree and cannot receive focus.
+**Action:** When implementing or fixing custom toggle patterns, make the trigger visually hidden but still in the accessibility tree (e.g., using `clip: rect(0, 0, 0, 0)` and `width: 1px; height: 1px`) and ensure it has proper focus styles (using `:focus-visible` on the trigger and applying it to the adjacent `label`).

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -11,6 +11,27 @@ $focus-color: #82aaff;
   font-weight: bold;
 }
 
+/* Accessible mobile navigation trigger */
+.site-nav .nav-trigger {
+  /* Override default display: none to make it focusable */
+  display: block !important;
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.site-nav .nav-trigger:focus-visible + label {
+  outline: 2px solid $focus-color;
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
 /* Reading Progress Bar */
 .reading-progress-bar {
   position: fixed;


### PR DESCRIPTION
* 💡 **What:** Replaced `display: none` on the mobile `.nav-trigger` checkbox with a visually hidden approach (`clip: rect(0,0,0,0)`, `width: 1px`, etc.) and added a clear `:focus-visible` state to its adjacent label. Added a journal entry documenting the learning.
* 🎯 **Why:** The default theme's implementation made the mobile navigation menu completely inaccessible via keyboard because elements with `display: none` cannot receive focus.
* 📸 **Before/After:** Before, pressing Tab on a mobile viewport would skip the navigation trigger entirely. Now, pressing Tab focuses the trigger and displays a blue outline around the hamburger icon.
* ♿ **Accessibility:** This ensures the primary mobile navigation is fully keyboard accessible.

---
*PR created automatically by Jules for task [8037396686987711277](https://jules.google.com/task/8037396686987711277) started by @tsainez*