### PR TITLE
🎨 Palette: Accessible Mobile Navigation Menu

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -17,3 +17,7 @@
 ## 2025-05-23 - Context-Aware Anchor Links
 **Learning:** Repeated interactive elements like "Copy link" buttons need unique accessible names to be useful. A generic "Copy link to section" label forces screen reader users to guess the context.
 **Action:** Append the associated section title to the `aria-label` (e.g., "Copy link to section: Introduction") and ensure this specific label is restored after any temporary state changes (like "Copied!").
+
+## 2025-05-24 - Accessible Mobile Navigation in Minima
+**Learning:** The default Jekyll Minima theme hides the mobile navigation checkbox trigger (`.nav-trigger`) using `display: none`. This completely removes it from the accessibility tree, making it impossible for keyboard users to focus and open the mobile menu.
+**Action:** When using or customizing themes with CSS-only mobile menus (checkbox hack), never use `display: none` on the input. Instead, visually hide it using `clip` and `width/height: 1px`, and apply `:focus-visible` styles to the adjacent label so keyboard users have a visible focus indicator.

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -488,3 +488,26 @@ h6:hover .anchor-link {
     page-break-inside: avoid;
   }
 }
+
+/* Mobile Navigation Accessibility Enhancement */
+@media screen and (max-width: 600px) {
+  .site-nav .nav-trigger {
+    /* Visually hide the input instead of display: none to keep it in the accessibility tree */
+    display: block !important;
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  /* Apply focus visible styles to the adjacent label when the hidden input receives focus */
+  .site-nav .nav-trigger:focus-visible + label[for="nav-trigger"] {
+    outline: 2px solid $focus-color;
+    outline-offset: 2px;
+  }
+}


### PR DESCRIPTION
## 💡 What
Modified the mobile navigation trigger styling (`.nav-trigger`) in `assets/main.scss` to use the `clip` pattern for visual hiding instead of `display: none`. Added an adjacent sibling selector to show a visible focus outline on the hamburger menu `<label>` when the visually hidden input receives focus.

## 🎯 Why
The default Jekyll Minima theme hides the mobile navigation checkbox trigger using `display: none`. This completely removes it from the accessibility tree, making it impossible for keyboard users or screen reader users to focus and open the mobile menu. By visually hiding it while keeping it in the DOM and providing a visual focus indicator, it is now fully keyboard accessible.

## 📸 Before/After
Before: Pressing 'Tab' on mobile skips the hamburger menu completely.
After: Pressing 'Tab' focuses the hamburger menu, clearly indicated by a focus outline (`$focus-color`), and pressing 'Space' toggles the menu.

## ♿ Accessibility
-   Keeps the `<input type="checkbox">` trigger in the accessibility tree for screen readers.
-   Provides a visible focus state for keyboard-only users using `:focus-visible`.
-   Addresses a critical usability block for mobile navigation.

---
*PR created automatically by Jules for task [17093044177041664744](https://jules.google.com/task/17093044177041664744) started by @tsainez*