### PR TITLE
⚡ Bolt: Optimize Jekyll build by skipping DOM parsing when possible

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -18,3 +18,7 @@
 ## 2025-02-19 - Layout vs Composite Animations on Scroll
 **Learning:** Animating geometry properties like `width` during scroll events forces the browser to recalculate layout and repaint on every frame, which is extremely expensive on the main thread.
 **Action:** Always animate using GPU-composited properties (like `transform: scaleX`) and `will-change: transform`. Set `width: 100%` and scale it from `0` to `1`. This offloads the work to the GPU and avoids main thread layout thrashing.
+
+## 2025-10-24 - Optimizing Expensive Post-Render DOM Parsing
+**Learning:** Using heavy parsers like Nokogiri on every single HTML document during Jekyll's `post_render` phase is extremely slow. For modifications that only affect specific elements (like `<a target="_blank">`), parsing the entire DOM unconditionally for every page causes a major build performance bottleneck.
+**Action:** Use a fast String Regex check (e.g., `match?(/target\s*=\s*['"]_blank['"]/i)`) to determine if the document even contains the target pattern. Only instantiate the expensive DOM parser if the pattern exists, effectively skipping the overhead for the majority of pages.

--- a/_plugins/external_links.rb
+++ b/_plugins/external_links.rb
@@ -4,6 +4,11 @@ Jekyll::Hooks.register [:documents, :pages], :post_render do |doc|
   require 'nokogiri'
 
   raw_html = doc.output
+
+  # Bolt Optimization: Fast fail with Regex before expensive Nokogiri parsing
+  # If the document doesn't contain target="_blank", there's nothing to do
+  next unless raw_html.match?(/target\s*=\s*['"]_blank['"]/i)
+
   # heuristic to detect if it's a full document or a fragment
   is_full_doc = raw_html.lstrip.start_with?("<!DOCTYPE", "<html")
 


### PR DESCRIPTION
### 💡 What
Added a fast fail regex check (`match?(/target\s*=\s*['"]_blank['"]/i)`) to `_plugins/external_links.rb` before instantiating the expensive Nokogiri parser. The block will early exit (using `next`) if the HTML document doesn't contain the target pattern.

### 🎯 Why
Parsing every HTML document unconditionally with Nokogiri during the `post_render` phase is extremely slow. Since this plugin only needs to append `rel="noopener noreferrer"` to external links with `target="_blank"`, documents without `target="_blank"` don't need to be parsed into a DOM tree at all. 

### 📊 Impact
Significantly reduces Jekyll build times by turning O(N) expensive DOM parses into mostly O(N) fast regex matches, where N is the total number of HTML documents. The heavy DOM parsing is now isolated only to pages that actually need it.

### 🔬 Measurement
This can be measured by timing the `bundle exec jekyll build` command before and after this change, particularly on larger Jekyll sites. The functional behavior remains identical, which was verified by the suite in `tests/verify_external_links_plugin.rb` and the HTML-Proofer checks during the build.

---
*PR created automatically by Jules for task [14730721524517509981](https://jules.google.com/task/14730721524517509981) started by @tsainez*