### PR TITLE
Skip site's own absolute URLs in html-proofer external link check

### DIFF
--- a/spec/site_spec.rb
+++ b/spec/site_spec.rb
@@ -7,7 +7,10 @@ describe 'Jekyll Site' do
       :check_img_http => true,
       :disable_external => false, # Enable external link checking
       :enforce_https => false,
-      :ignore_urls => [],
+      # Ignore self-referencing absolute URLs (e.g. canonical/og:url emitted by
+      # jekyll-seo-tag). New pages 404 here until they're deployed to production,
+      # so we treat them as internal links rather than fetching them.
+      :ignore_urls => [%r{\Ahttps?://tonysainez\.com(/|\z)}],
       :hydra => { :max_concurrency => 5 },
       :typhoeus => {
         :connecttimeout => 15,


### PR DESCRIPTION
jekyll-seo-tag emits a canonical link and og:url for every page using
the configured site.url. html-proofer then fetches those as external
links, which 404 for any new page that hasn't been deployed yet — most
recently /image-map/, added in #218.

Match the site's own URLs against ignore_urls so they're skipped by the
external check; internal link checking still validates that the
underlying routes exist in _site.