### PR TITLE
🎨 Palette: Make skip-link target focusable

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -15,3 +15,7 @@
 ## 2026-05-10 - Mobile Navigation Accessibility
 **Learning:** Overriding default theme styles that use `display: none` for custom toggle patterns (like the "checkbox hack" used for mobile navigation) is necessary for keyboard accessibility. Elements hidden with `display: none` are removed from the accessibility tree and cannot receive focus.
 **Action:** When implementing or fixing custom toggle patterns, make the trigger visually hidden but still in the accessibility tree (e.g., using `clip: rect(0, 0, 0, 0)` and `width: 1px; height: 1px`) and ensure it has proper focus styles (using `:focus-visible` on the trigger and applying it to the adjacent `label`).
+
+## 2026-05-17 - Skip Link Targets Must Be Focusable
+**Learning:** A "Skip to content" link visually scrolls the user to the main content, but unless the target container has `tabindex="-1"`, programmatic focus and screen reader context remain at the top of the page. Without this, the next `Tab` press starts the navigation cycle over again, defeating the purpose of the skip link.
+**Action:** Always add `tabindex="-1"` to the container element referenced by a skip link's `href` (e.g., `<main id="main-content" tabindex="-1">`).

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,7 +8,7 @@
 
     {%- include header.html -%}
 
-    <main id="main-content" class="page-content" aria-label="Content">
+    <main id="main-content" class="page-content" aria-label="Content" tabindex="-1">
       <div class="wrapper">
         {{ content }}
       </div>

--- a/_layouts/onepager.html
+++ b/_layouts/onepager.html
@@ -29,7 +29,7 @@
     <h1>{{ site.title | escape }}</h1>
     <p>{{ site.description | escape }}</p>
   </div>
-  <div id="main-content" class="onepager-section">
+  <div id="main-content" class="onepager-section" tabindex="-1">
     {{ content }}
   </div>
   <div class="onepager-footer">


### PR DESCRIPTION
💡 **What**: Added `tabindex="-1"` to the `#main-content` target elements in `_layouts/default.html` and `_layouts/onepager.html`.
🎯 **Why**: When a user clicks a "skip to content" link, the browser scrolls to the target. However, without `tabindex="-1"`, the target container cannot receive programmatic focus. This means the next `Tab` keystroke or screen reader focus cycle restarts from the top of the page, completely defeating the purpose of the skip link for keyboard/assistive tech users.
♿ **Accessibility**: Ensures skip links functionally transfer focus to the content area, allowing immediate navigation of the main content.
📝 **Journal**: Documented learning in `.jules/palette.md`.

---
*PR created automatically by Jules for task [7901315794628807848](https://jules.google.com/task/7901315794628807848) started by @tsainez*