### PR TITLE
🎨 Palette: Improve accessible names and tooltips for icon controls

### DIFF
--- a/_includes/back-to-top.html
+++ b/_includes/back-to-top.html
@@ -1,4 +1,4 @@
-<button id="back-to-top" class="back-to-top" aria-label="Back to top">
+<button id="back-to-top" class="back-to-top" aria-label="Back to top" title="Back to top">
   <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
     <path d="M18 15l-6-6-6 6"/>
   </svg>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -7,8 +7,8 @@
 
     {%- if page_paths -%}
       <nav class="site-nav">
-        <input type="checkbox" id="nav-trigger" class="nav-trigger" />
-        <label for="nav-trigger" aria-label="Toggle navigation">
+        <input type="checkbox" id="nav-trigger" class="nav-trigger" aria-label="Toggle navigation" />
+        <label for="nav-trigger" title="Toggle navigation">
           <span class="menu-icon">
             <svg viewBox="0 0 18 15" width="18px" height="15px">
               <path d="M18,1.484c0,0.82-0.665,1.484-1.484,1.484H1.484C0.665,2.969,0,2.304,0,1.484l0,0C0,0.665,0.665,0,1.484,0 h15.032C17.335,0,18,0.665,18,1.484L18,1.484z M18,7.516C18,8.335,17.335,9,16.516,9H1.484C0.665,9,0,8.335,0,7.516l0,0 c0-0.82,0.665-1.484,1.484-1.484h15.032C17.335,6.031,18,6.696,18,7.516L18,7.516z M18,13.516C18,14.335,17.335,15,16.516,15H1.484 C0.665,15,0,14.335,0,13.516l0,0c0-0.82,0.665-1.483,1.484-1.483h15.032C17.335,12.031,18,12.695,18,13.516L18,13.516z"/>


### PR DESCRIPTION
🎨 **Palette: Icon Control UX and Accessibility Improvements**

💡 **What:** 
Added native hover tooltips (`title` attributes) to the icon-only Back to Top button and the Mobile Navigation trigger. Moved the `aria-label` for the mobile navigation from the visual `<label>` to the interactable `<input>` field.

🎯 **Why:** 
For visual users, icon-only buttons without text can be ambiguous; native tooltips provide immediate, unobtrusive context on hover. 
For screen reader users, the "checkbox hack" used for the mobile menu requires the accessible name (`aria-label`) to be directly on the `<input type="checkbox">` element. Placing it on the `<label>` is not consistently read when the user focuses the invisible input element itself.

♿ **Accessibility:**
- Ensures screen readers announce "Toggle navigation" when focusing the invisible navigation checkbox.
- Ensures sighted users see "Back to top" and "Toggle navigation" tooltips when hovering over the respective icon buttons.

---
*PR created automatically by Jules for task [12688517742937275928](https://jules.google.com/task/12688517742937275928) started by @tsainez*