### PR TITLE
🛡️ Sentinel: [HIGH] Fix Stored XSS via Liquid Output in URL Attributes

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -48,3 +48,8 @@
 **Vulnerability:** Unescaped Liquid output variables (`site.email` and `site.github_username`) in Markdown files (`image-map.markdown`) allowed for Stored XSS if malicious content was entered in configuration, particularly when injected directly into attributes or URLs.
 **Learning:** In Jekyll, Markdown files with front matter parse Liquid tags before rendering HTML. Any user-controlled configuration variables (like `site.email` or `site.github_username`) injected into HTML attributes within these content files must be explicitly escaped (e.g., using `escape` or `cgi_escape`) to prevent Stored XSS.
 **Prevention:** Always audit Jekyll content files for raw variable output in attributes and URLs. Apply `| cgi_escape | escape` to variables in URLs, and `| escape` to general attribute variables.
+
+## 2026-05-25 - [Stored XSS via Liquid Output in URL Attributes]
+**Vulnerability:** Unescaped Liquid output variables for URLs (e.g., `page.url`, `post.url`, `my_page.url`) were directly injected into HTML attributes (like `href`) in layout files (`_layouts/home.html`, `_layouts/post.html`, `_includes/header.html`). If a crafted `permalink` were defined in the front matter, it could lead to attribute breakout and Stored XSS.
+**Learning:** Liquid template engines, unlike some others, do not auto-escape their output by default. Any variable injected into an HTML attribute, including path or URL variables generated from potentially user-controllable input (like front matter), needs to be explicitly escaped.
+**Prevention:** Always append the `| escape` filter for any Liquid variable injected into HTML attributes unless it is strictly hardcoded and trusted.

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -20,7 +20,7 @@
           {%- for path in page_paths -%}
             {%- assign my_page = site.pages | where: "path", path | first -%}
             {%- if my_page.title -%}
-            <a class="page-link" href="{{ my_page.url | relative_url }}"{% if my_page.url == page.url %} aria-current="page"{% endif %}>{{ my_page.title | escape }}</a>
+            <a class="page-link" href="{{ my_page.url | relative_url | escape }}"{% if my_page.url == page.url %} aria-current="page"{% endif %}>{{ my_page.title | escape }}</a>
             {%- endif -%}
           {%- endfor -%}
         </div>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -25,7 +25,7 @@ layout: default
           {% endif %}
         </span>
         <h3>
-          <a class="post-link" href="{{ post.url | relative_url }}">
+          <a class="post-link" href="{{ post.url | relative_url | escape }}">
             {{ post.title | escape }}
           </a>
         </h3>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -32,19 +32,19 @@ layout: default
     {%- include disqus_comments.html -%}
   {%- endif -%}
 
-  <a class="u-url" href="{{ page.url | relative_url }}" hidden></a>
+  <a class="u-url" href="{{ page.url | relative_url | escape }}" hidden></a>
 
   <div class="post-navigation">
     {% if page.previous.url %}
       <div class="nav-previous">
-        <a href="{{ page.previous.url | relative_url }}" rel="prev" aria-label="Previous post: {{ page.previous.title | escape }}">
+        <a href="{{ page.previous.url | relative_url | escape }}" rel="prev" aria-label="Previous post: {{ page.previous.title | escape }}">
           <span aria-hidden="true" class="nav-arrow left">&laquo;</span> {{ page.previous.title | escape }}
         </a>
       </div>
     {% endif %}
     {% if page.next.url %}
       <div class="nav-next">
-        <a href="{{ page.next.url | relative_url }}" rel="next" aria-label="Next post: {{ page.next.title | escape }}">
+        <a href="{{ page.next.url | relative_url | escape }}" rel="next" aria-label="Next post: {{ page.next.title | escape }}">
           {{ page.next.title | escape }} <span aria-hidden="true" class="nav-arrow right">&raquo;</span>
         </a>
       </div>


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Unescaped Liquid output for URLs (e.g., `page.url`, `post.url`) inside HTML attributes (`href`) allowed for potential Stored XSS if a crafted `permalink` is provided via front matter.
🎯 Impact: Attackers (malicious authors) could break out of the HTML attribute and execute arbitrary JavaScript.
🔧 Fix: Appended the `| escape` Liquid filter wherever URLs are rendered into attributes inside `_includes/header.html`, `_layouts/home.html`, and `_layouts/post.html`.
✅ Verification: Ensure the Jekyll build succeeds and verify tests pass. No layout or navigation changes occurred for legitimate users.

---
*PR created automatically by Jules for task [3862528531924996623](https://jules.google.com/task/3862528531924996623) started by @tsainez*