### PR TITLE
🎨 Palette: Improve accessibility for mobile navigation and icon buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -19,3 +19,7 @@
 ## 2026-05-17 - Skip Link Targets Must Be Focusable
 **Learning:** A "Skip to content" link visually scrolls the user to the main content, but unless the target container has `tabindex="-1"`, programmatic focus and screen reader context remain at the top of the page. Without this, the next `Tab` press starts the navigation cycle over again, defeating the purpose of the skip link.
 **Action:** Always add `tabindex="-1"` to the container element referenced by a skip link's `href` (e.g., `<main id="main-content" tabindex="-1">`).
+
+## 2026-10-31 - Checkbox Hack Accessibility
+**Learning:** For accessible 'checkbox hack' implementations (e.g., mobile navigation via hidden checkbox), the `aria-label` must be placed directly on the `<input type="checkbox">` element, not its visual `<label>`, to ensure proper screen reader announcements. Adding `title` attributes to icon-only buttons provides native tooltips for sighted users.
+**Action:** Always check ARIA label placement for hidden inputs acting as toggles, and use `title` attributes for icon-only interactions.

--- a/_includes/back-to-top.html
+++ b/_includes/back-to-top.html
@@ -1,4 +1,4 @@
-<button id="back-to-top" class="back-to-top" aria-label="Back to top">
+<button id="back-to-top" class="back-to-top" aria-label="Back to top" title="Back to top">
   <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
     <path d="M18 15l-6-6-6 6"/>
   </svg>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -7,10 +7,10 @@
 
     {%- if page_paths -%}
       <nav class="site-nav">
-        <input type="checkbox" id="nav-trigger" class="nav-trigger" />
-        <label for="nav-trigger" aria-label="Toggle navigation">
+        <input type="checkbox" id="nav-trigger" class="nav-trigger" aria-label="Toggle navigation" />
+        <label for="nav-trigger" title="Toggle navigation">
           <span class="menu-icon">
-            <svg viewBox="0 0 18 15" width="18px" height="15px">
+            <svg viewBox="0 0 18 15" width="18px" height="15px" aria-hidden="true">
               <path d="M18,1.484c0,0.82-0.665,1.484-1.484,1.484H1.484C0.665,2.969,0,2.304,0,1.484l0,0C0,0.665,0.665,0,1.484,0 h15.032C17.335,0,18,0.665,18,1.484L18,1.484z M18,7.516C18,8.335,17.335,9,16.516,9H1.484C0.665,9,0,8.335,0,7.516l0,0 c0-0.82,0.665-1.484,1.484-1.484h15.032C17.335,6.031,18,6.696,18,7.516L18,7.516z M18,13.516C18,14.335,17.335,15,16.516,15H1.484 C0.665,15,0,14.335,0,13.516l0,0c0-0.82,0.665-1.483,1.484-1.483h15.032C17.335,12.031,18,12.695,18,13.516L18,13.516z"/>
             </svg>
           </span>


### PR DESCRIPTION
🎨 Palette: Improve accessibility for mobile navigation and icon buttons

💡 What: Moved the aria-label to the input element for the mobile navigation checkbox hack, and added a title attribute to the label. Also added a title attribute to the back-to-top button.
🎯 Why: Screen readers announce the accessible name of the input control itself, not just its associated visual label, especially for the CSS "checkbox hack". Adding title attributes provides native tooltips for sighted users.
📸 Before/After: Visual changes verified to be non-destructive.
♿ Accessibility: Improved screen reader announcements and added tooltips.

---
*PR created automatically by Jules for task [14612396410632390064](https://jules.google.com/task/14612396410632390064) started by @tsainez*