### PR TITLE
🎨 Palette: Add escape hatch to 404 page

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -29,3 +29,7 @@
 ## 2026-10-31 - Checkbox Hack Accessibility
 **Learning:** For accessible 'checkbox hack' implementations (e.g., mobile navigation via hidden checkbox), the `aria-label` must be placed directly on the `<input type="checkbox">` element, not its visual `<label>`, to ensure proper screen reader announcements. Adding `title` attributes to icon-only buttons provides native tooltips for sighted users.
 **Action:** Always check ARIA label placement for hidden inputs acting as toggles, and use `title` attributes for icon-only interactions.
+
+## 2026-11-04 - Escape Hatches for Dead Ends
+**Learning:** 404 pages and empty states without clear calls to action create dead-ends that frustrate users. Providing a simple escape hatch, like a link back to the homepage, significantly improves the user experience by offering a clear path forward.
+**Action:** Always provide a clear escape hatch (e.g., a link to the homepage or main dashboard) on 404 pages, empty states, and error screens.

--- a/404.html
+++ b/404.html
@@ -8,4 +8,5 @@ layout: default
 
   <p><strong>Page not found :(</strong></p>
   <p>The requested page could not be found.</p>
+  <p><a href="{{ "/" | relative_url }}">Return to homepage</a></p>
 </div>


### PR DESCRIPTION
💡 **What:** Added a "Return to homepage" link to the 404 error page. Also added a journal entry documenting the importance of escape hatches in empty states/error pages.
🎯 **Why:** To prevent user dead-ends when encountering a broken link or non-existent page, providing a clear path forward and improving the overall UX.
📸 **Before/After:** The 404 page now contains a hyperlink below the error text to navigate back to the root of the site.
♿ **Accessibility:** The link provides standard, predictable navigation out of an error state.

---
*PR created automatically by Jules for task [18347809442186727323](https://jules.google.com/task/18347809442186727323) started by @tsainez*