### PR TITLE
🎨 Palette: Add "Return to homepage" escape hatch to 404 page

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -29,3 +29,6 @@
 ## 2026-10-31 - Checkbox Hack Accessibility
 **Learning:** For accessible 'checkbox hack' implementations (e.g., mobile navigation via hidden checkbox), the `aria-label` must be placed directly on the `<input type="checkbox">` element, not its visual `<label>`, to ensure proper screen reader announcements. Adding `title` attributes to icon-only buttons provides native tooltips for sighted users.
 **Action:** Always check ARIA label placement for hidden inputs acting as toggles, and use `title` attributes for icon-only interactions.
+## 2026-11-04 - 404 Page Escape Hatches
+**Learning:** 404 pages and empty states can become dead-ends for users, leading to frustration and abandonment. Providing a clear escape hatch, such as a link to the homepage, helps users recover from errors and continue their journey.
+**Action:** Always ensure that 404 pages, empty states, and error messages include clear and actionable paths forward, such as a "Return to homepage" link.

--- a/404.html
+++ b/404.html
@@ -8,4 +8,5 @@ layout: default
 
   <p><strong>Page not found :(</strong></p>
   <p>The requested page could not be found.</p>
+  <p><a href="{{ '/' | relative_url }}">Return to homepage</a></p>
 </div>


### PR DESCRIPTION
💡 **What:** Added a "Return to homepage" link to the 404 Error page. Also documented the importance of escape hatches in the `.jules/palette.md` journal.
🎯 **Why:** 404 pages without clear navigation options become dead-ends, causing user frustration and increasing bounce rates. Providing an explicit "escape hatch" allows users to easily recover and continue browsing the site.
📸 **Before/After:** The 404 page now features a clear, accessible text link returning to `/`.
♿ **Accessibility:** The link uses standard `a` tag semantics and inherits the site's default focus styles for keyboard users.

---
*PR created automatically by Jules for task [1370208735210987993](https://jules.google.com/task/1370208735210987993) started by @tsainez*