### PR TITLE
🎨 Palette: Add escape hatch to 404 page

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -29,3 +29,7 @@
 ## 2026-10-31 - Checkbox Hack Accessibility
 **Learning:** For accessible 'checkbox hack' implementations (e.g., mobile navigation via hidden checkbox), the `aria-label` must be placed directly on the `<input type="checkbox">` element, not its visual `<label>`, to ensure proper screen reader announcements. Adding `title` attributes to icon-only buttons provides native tooltips for sighted users.
 **Action:** Always check ARIA label placement for hidden inputs acting as toggles, and use `title` attributes for icon-only interactions.
+
+## 2026-05-27 - Escape Hatches for Dead Ends
+**Learning:** 404 pages and empty states naturally feel like a dead end for users. Without a clear path forward, the user experience becomes frustrating. Providing a clear escape hatch (like a link back to the homepage or main feed) is a small but critical touch that makes the interface more pleasant to use.
+**Action:** Always provide an explicit and clear escape hatch (e.g., "Return to Homepage") when designing or implementing 404 error pages or empty states to prevent users from getting stuck.

--- a/404.html
+++ b/404.html
@@ -8,4 +8,7 @@ layout: default
 
   <p><strong>Page not found :(</strong></p>
   <p>The requested page could not be found.</p>
+  <p style="margin-top: 2rem;">
+    <a href="{{ '/' | relative_url | escape }}" class="btn" style="text-decoration: underline;">Return to Homepage</a>
+  </p>
 </div>


### PR DESCRIPTION
💡 What: Added an explicit escape hatch (a "Return to Homepage" link) to the 404 error page.

🎯 Why: To prevent user dead-ends when they navigate to missing content, improving the overall site usability and keeping users engaged rather than forcing them to use the browser's back button or leave.

♿ Accessibility: The link uses standard routing and semantic HTML which integrates perfectly with keyboard navigation without custom interactive JavaScript.

---
*PR created automatically by Jules for task [18257441034780261342](https://jules.google.com/task/18257441034780261342) started by @tsainez*