### PR TITLE
🎨 Palette: Add Escape Hatch to 404 Page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__/
 *.pyc
 node_modules/
 test-results/
+jekyll_serve.log

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -29,3 +29,7 @@
 ## 2026-10-31 - Checkbox Hack Accessibility
 **Learning:** For accessible 'checkbox hack' implementations (e.g., mobile navigation via hidden checkbox), the `aria-label` must be placed directly on the `<input type="checkbox">` element, not its visual `<label>`, to ensure proper screen reader announcements. Adding `title` attributes to icon-only buttons provides native tooltips for sighted users.
 **Action:** Always check ARIA label placement for hidden inputs acting as toggles, and use `title` attributes for icon-only interactions.
+
+## 2026-11-10 - 404 Pages Escape Hatch
+**Learning:** 404 pages and empty states without a clear way out create user dead-ends. Users facing an error need a visible path forward to recover, otherwise they're likely to abandon the site.
+**Action:** Always provide a clear escape hatch (e.g., a link to the homepage or main dashboard) on 404 pages and empty states.

--- a/404.html
+++ b/404.html
@@ -8,4 +8,5 @@ layout: default
 
   <p><strong>Page not found :(</strong></p>
   <p>The requested page could not be found.</p>
+  <p><a href="{{ '/' | relative_url | escape }}">Return to homepage</a></p>
 </div>


### PR DESCRIPTION
As part of the Palette agent's persona to add a micro-UX enhancement, I've identified that the site's `404.html` page had no escape hatch, creating a "dead end" for users.

I have updated `404.html` with a clear "Return to homepage" link.
Additionally, I've added a critical learning to `.jules/palette.md` detailing the importance of escape hatches in error states.

These changes are verified via testing and frontend Playwright screenshot and recording.

---
*PR created automatically by Jules for task [8054759333773384893](https://jules.google.com/task/8054759333773384893) started by @tsainez*