### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix case-sensitive target="_blank" bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -57,3 +57,8 @@
 **Vulnerability:** Unescaped Liquid output variables for URLs (e.g., `page.url`, `post.url`, `my_page.url`) were directly injected into HTML attributes (like `href`) in layout files (`_layouts/home.html`, `_layouts/post.html`, `_includes/header.html`). If a crafted `permalink` were defined in the front matter, it could lead to attribute breakout and Stored XSS.
 **Learning:** Liquid template engines, unlike some others, do not auto-escape their output by default. Any variable injected into an HTML attribute, including path or URL variables generated from potentially user-controllable input (like front matter), needs to be explicitly escaped.
 **Prevention:** Always append the `| escape` filter for any Liquid variable injected into HTML attributes unless it is strictly hardcoded and trusted.
+
+## 2026-06-03 - [Case-Sensitive Filter Bypass in Nokogiri]
+**Vulnerability:** The external links plugin relied on Nokogiri's `a[target="_blank"]` CSS selector, which is strictly case-sensitive. This meant links authored with `target="_BLANK"` bypassed the filter and were not assigned `rel="noopener noreferrer"`, leaving them vulnerable to reverse tabnabbing.
+**Learning:** HTML attribute values like `target` are often treated case-insensitively by browsers but are evaluated strictly by parser selectors unless specifically configured. In Nokogiri, CSS selectors are case-sensitive.
+**Prevention:** Replaced the CSS selector with an XPath query using the `translate()` function to enforce case-insensitive matching (`//a[translate(@target, "ABCDEFGHIJKLMNOPQRSTUVWXYZ", "abcdefghijklmnopqrstuvwxyz")="_blank"]`), ensuring consistent and robust protection regardless of authored case.

--- a/_plugins/external_links.rb
+++ b/_plugins/external_links.rb
@@ -20,7 +20,7 @@ Jekyll::Hooks.register [:documents, :pages], :post_render do |doc|
     page = Nokogiri::HTML::DocumentFragment.parse(raw_html)
   end
 
-  page.css('a[target="_blank"]').each do |link|
+  page.xpath('descendant-or-self::a[translate(@target, "ABCDEFGHIJKLMNOPQRSTUVWXYZ", "abcdefghijklmnopqrstuvwxyz")="_blank"]').each do |link|
     href = link['href']
     next unless href
 

--- a/tests/verify_external_links_plugin.rb
+++ b/tests/verify_external_links_plugin.rb
@@ -51,3 +51,5 @@ test("Target First", '<a target="_blank" href="https://reversed.com">Link</a>', 
 test("Target First Proto Relative", '<a target="_blank" href="//reversed-proto.com">Link</a>', true)
 test("Internal Link", '<a href="/internal" target="_blank">Link</a>', false)
 test("Existing Rel", '<a href="https://google.com" target="_blank" rel="nofollow">Link</a>', true)
+test("Case Insensitive Target", '<a href="https://example.com" target="_BLANK">Link</a>', true)
+test("Mixed Case Target", '<a href="https://example.com" target="_Blank">Link</a>', true)


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix case-sensitive target="_blank" bypass

🚨 Severity: MEDIUM
💡 Vulnerability: The external links plugin used a case-sensitive CSS selector (`a[target="_blank"]`) to append `rel="noopener noreferrer"`. Links authored with `target="_BLANK"` or other case variations evaded this filter.
🎯 Impact: Unprotected links opening in a new tab could be exploited for reverse tabnabbing (where the new page can access and navigate the `window.opener`).
🔧 Fix: Updated the Nokogiri selector to use a case-insensitive XPath query with `translate()`, ensuring the security attributes are applied regardless of casing. Added unit tests for mixed-case scenarios.
✅ Verification: Ran `verify_external_links_plugin.rb` and `rake spec` successfully.

---
*PR created automatically by Jules for task [5854690712718916202](https://jules.google.com/task/5854690712718916202) started by @tsainez*