### PR TITLE
🎨 Palette: Add escape hatch to 404 page

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -29,3 +29,7 @@
 ## 2026-10-31 - Checkbox Hack Accessibility
 **Learning:** For accessible 'checkbox hack' implementations (e.g., mobile navigation via hidden checkbox), the `aria-label` must be placed directly on the `<input type="checkbox">` element, not its visual `<label>`, to ensure proper screen reader announcements. Adding `title` attributes to icon-only buttons provides native tooltips for sighted users.
 **Action:** Always check ARIA label placement for hidden inputs acting as toggles, and use `title` attributes for icon-only interactions.
+
+## 2026-11-05 - Escape Hatches for Dead Ends
+**Learning:** A 404 page or an empty state without clear navigation options is a dead end for users, leading to frustration and abandonment.
+**Action:** Always provide a clear, accessible escape hatch, such as a "Return to Homepage" link, on 404 pages and empty states to guide users back to safety.

--- a/404.html
+++ b/404.html
@@ -8,4 +8,5 @@ layout: default
 
   <p><strong>Page not found :(</strong></p>
   <p>The requested page could not be found.</p>
+  <p><a href="{{ '/' | relative_url | escape }}" class="btn">Return to Homepage</a></p>
 </div>


### PR DESCRIPTION
**💡 What:** Added a clear, accessible "Return to Homepage" link to the 404 error page.

**🎯 Why:** 404 pages without navigation options create a dead end for users, leading to frustration. Providing an explicit escape hatch guides users back to safety and keeps them engaged with the site.

**📸 Before/After:** See the verification screenshot for the new layout.

**♿ Accessibility:** Standard HTML anchor link with proper Jekyll escaping to ensure robust routing and screen reader compatibility.

Recorded this learning in `.jules/palette.md`.

---
*PR created automatically by Jules for task [12212189728499948783](https://jules.google.com/task/12212189728499948783) started by @tsainez*