### PR TITLE
🎨 Palette: Add escape hatch to 404 page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__/
 *.pyc
 node_modules/
 test-results/
+jekyll_serve.log

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -29,3 +29,7 @@
 ## 2026-10-31 - Checkbox Hack Accessibility
 **Learning:** For accessible 'checkbox hack' implementations (e.g., mobile navigation via hidden checkbox), the `aria-label` must be placed directly on the `<input type="checkbox">` element, not its visual `<label>`, to ensure proper screen reader announcements. Adding `title` attributes to icon-only buttons provides native tooltips for sighted users.
 **Action:** Always check ARIA label placement for hidden inputs acting as toggles, and use `title` attributes for icon-only interactions.
+
+## 2026-11-04 - Clear Escape Hatches
+**Learning:** When users hit a dead-end like a 404 page or an empty search results state, it can be frustrating and may lead to them abandoning the site.
+**Action:** Always provide a clear "escape hatch" in dead-end states, such as a prominent link back to the homepage or primary navigation area, to help users recover quickly.

--- a/404.html
+++ b/404.html
@@ -8,4 +8,5 @@ layout: default
 
   <p><strong>Page not found :(</strong></p>
   <p>The requested page could not be found.</p>
+  <p><a href="{{ '/' | relative_url }}">Return to the homepage</a></p>
 </div>


### PR DESCRIPTION
What: Added a link back to the homepage in 404.html.
Why: Users who encounter a 404 dead-end can get easily frustrated and may abandon the site if there isn't an intuitive way out.
Before: 404 page just displayed "The requested page could not be found."
After: 404 page now includes a "Return to the homepage" link.
Accessibility: Reduces cognitive load and ensures a clear navigation path.

---
*PR created automatically by Jules for task [14588284283466616019](https://jules.google.com/task/14588284283466616019) started by @tsainez*