### PR TITLE
⚡ Bolt: [performance improvement] Optimize Nokogiri string loop

### DIFF
--- a/_plugins/external_links.rb
+++ b/_plugins/external_links.rb
@@ -25,7 +25,9 @@ Jekyll::Hooks.register [:documents, :pages], :post_render do |doc|
     next unless href
 
     # Check for external links (http, https, or protocol-relative //)
-    if href.strip =~ %r{\A(https?:|//)}
+    # ⚡ Bolt Optimization: Use `match?` with regex handling whitespace
+    # instead of `strip =~` to avoid creating new string objects in memory.
+    if href.match?(/\A\s*(?:https?:|\/\/)/i)
       rel = link['rel'] || ''
       parts = rel.split(/\s+/)
 


### PR DESCRIPTION
💡 What: Replaced `href.strip =~ %r{\A(https?:|//)}` with `href.match?(/\A\s*(?:https?:|\/\/)/i)` in the Jekyll hook `_plugins/external_links.rb`.
🎯 Why: In Ruby, checking string prefixes using `string.strip =~ /regex/` inside iterative loops unnecessarily allocates new string objects. For a site generator parsing potentially hundreds of links across many files, this leads to unnecessary garbage collection overhead.
📊 Impact: Eliminates object creation on hot loops inside the Nokogiri link processor during `post_render`, leading to faster Jekyll builds on heavily linked sites.
🔬 Measurement: Verify build succeeds and HTML tests pass running `bundle exec jekyll build && bundle exec rake spec`. Check that external links still appropriately get appended with `rel="noopener noreferrer"`.

---
*PR created automatically by Jules for task [12464874012395484772](https://jules.google.com/task/12464874012395484772) started by @tsainez*