### PR TITLE
🎨 Palette: [UX improvement] Add empty state to homepage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ __pycache__/
 node_modules/
 test-results/
 jekyll_serve.log
+pnpm-lock.yaml
+jekyll_output.log

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -47,3 +47,7 @@
 ## 2026-11-04 - Clear Escape Hatches
 **Learning:** When users hit a dead-end like a 404 page or an empty search results state, it can be frustrating and may lead to them abandoning the site.
 **Action:** Always provide a clear "escape hatch" in dead-end states, such as a prominent link back to the homepage or primary navigation area, to help users recover quickly.
+
+## 2026-11-10 - Home Page Empty State
+**Learning:** A homepage listing posts can act as an empty state if there are no posts yet. Without an explicit message, users might think the site is broken or still loading.
+**Action:** Always provide an explicit empty state message (like "No posts found. Check back later!") for dynamic lists on the homepage to reassure users.

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -37,6 +37,11 @@ layout: default
     </ul>
 
     <p class="rss-subscribe">subscribe <a href="{{ "/feed.xml" | relative_url | escape }}">via RSS</a></p>
+  {%- else -%}
+    <h2 class="post-list-heading">{{ page.list_title | default: "Posts" | escape }}</h2>
+    <div class="empty-state">
+      <p>No posts found. Check back later!</p>
+    </div>
   {%- endif -%}
 
 </div>


### PR DESCRIPTION
Added a helpful "No posts found. Check back later!" message to the homepage when there are no posts.
A homepage listing posts acts as an empty state if there are no posts yet. Without an explicit message, users might think the site is broken or still loading.

---
*PR created automatically by Jules for task [11505032194358484154](https://jules.google.com/task/11505032194358484154) started by @tsainez*