### PR TITLE
🎨 Palette: [UX improvement] Add explicit empty state for missing posts

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -47,3 +47,7 @@
 ## 2026-11-04 - Clear Escape Hatches
 **Learning:** When users hit a dead-end like a 404 page or an empty search results state, it can be frustrating and may lead to them abandoning the site.
 **Action:** Always provide a clear "escape hatch" in dead-end states, such as a prominent link back to the homepage or primary navigation area, to help users recover quickly.
+
+## 2025-05-24 - Empty States for Dynamic Content
+**Learning:** A homepage listing posts must include an explicit empty state message when no posts exist. Otherwise, users might think the site is broken or still loading.
+**Action:** When creating or modifying lists of dynamic content (like blog posts), always add a fallback message (e.g., using `{% else %}` in Liquid) to reassure users and provide context.

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -37,6 +37,10 @@ layout: default
     </ul>
 
     <p class="rss-subscribe">subscribe <a href="{{ "/feed.xml" | relative_url | escape }}">via RSS</a></p>
+  {%- else -%}
+    <div class="empty-state">
+      <p>No posts have been published yet. Check back later!</p>
+    </div>
   {%- endif -%}
 
 </div>


### PR DESCRIPTION
💡 **What:** Added an explicit empty state message ("No posts have been published yet. Check back later!") to the posts list on the homepage (`_layouts/home.html`) using Liquid's `{% else %}` tag. Also documented this pattern in `.jules/palette.md`.
🎯 **Why:** Previously, if no posts were present, the section was simply blank. This acts as a dead-end that can confuse users, making them think the site is still loading or broken. Providing an explicit message resolves this confusion and improves the user experience.
📸 **Before/After:** The homepage now gracefully shows a helpful message when `_posts` is empty. (Verified visually via Playwright).
♿ **Accessibility:** N/A (Standard semantic HTML fallback).

---
*PR created automatically by Jules for task [18091338265823961754](https://jules.google.com/task/18091338265823961754) started by @tsainez*