### PR TITLE
🎨 Palette: Add explicit empty state for posts on homepage

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -47,3 +47,7 @@
 ## 2026-11-04 - Clear Escape Hatches
 **Learning:** When users hit a dead-end like a 404 page or an empty search results state, it can be frustrating and may lead to them abandoning the site.
 **Action:** Always provide a clear "escape hatch" in dead-end states, such as a prominent link back to the homepage or primary navigation area, to help users recover quickly.
+
+## 2026-11-04 - Empty State Messages
+**Learning:** Content listing pages (like a blog homepage) without explicit empty states can leave users confused or assuming the site is broken if there's no content to display.
+**Action:** Always provide an explicit empty state message (e.g., "No posts have been published yet") for list or collection pages to reassure users and guide them properly.

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -37,6 +37,10 @@ layout: default
     </ul>
 
     <p class="rss-subscribe">subscribe <a href="{{ "/feed.xml" | relative_url | escape }}">via RSS</a></p>
+  {%- else -%}
+    <div class="empty-state">
+      <p>No posts have been published yet. Please check back later!</p>
+    </div>
   {%- endif -%}
 
 </div>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,55 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.60.0
+        version: 1.60.0
+      playwright:
+        specifier: ^1.59.1
+        version: 1.60.0
+
+packages:
+
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+snapshots:
+
+  '@playwright/test@1.60.0':
+    dependencies:
+      playwright: 1.60.0
+
+  fsevents@2.3.2:
+    optional: true
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2


### PR DESCRIPTION
**What:** Added an `{% else %}` block to the posts loop in `_layouts/home.html` that displays an empty state message ("No posts have been published yet. Please check back later!"). Documented this insight in `.jules/palette.md`.
**Why:** Without content, collection pages look confusing or broken to users. Providing an explicit message reassures them and offers clear context.
**Accessibility/UX:** Improves the user experience by reducing confusion and preventing dead-ends. A well-crafted empty state is a foundational UX pattern for dynamic listings.
**Verification:** Verified via local build and Playwright screenshot showing the layout remains stable. HTML Proofer tests passed successfully.

---
*PR created automatically by Jules for task [5174983790400385693](https://jules.google.com/task/5174983790400385693) started by @tsainez*