### PR TITLE
🎨 Palette: [UX improvement] Add explicit empty state to homepage post list

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -47,3 +47,7 @@
 ## 2026-11-04 - Clear Escape Hatches
 **Learning:** When users hit a dead-end like a 404 page or an empty search results state, it can be frustrating and may lead to them abandoning the site.
 **Action:** Always provide a clear "escape hatch" in dead-end states, such as a prominent link back to the homepage or primary navigation area, to help users recover quickly.
+
+## 2026-11-10 - Empty List States
+**Learning:** A homepage listing posts must explicitly acknowledge when the list is empty (e.g., "No posts have been published yet.") rather than just displaying nothing. This prevents users from thinking the site is broken or still loading.
+**Action:** Always provide an explicit empty state message when a collection (like a list of blog posts) is empty.

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -37,6 +37,8 @@ layout: default
     </ul>
 
     <p class="rss-subscribe">subscribe <a href="{{ "/feed.xml" | relative_url | escape }}">via RSS</a></p>
+  {%- else -%}
+    <p class="empty-state">No posts have been published yet.</p>
   {%- endif -%}
 
 </div>


### PR DESCRIPTION
**What:** Added an explicit empty state message ("No posts have been published yet.") to the `_layouts/home.html` template that is displayed when there are no blog posts.
**Why:** To prevent a dead-end experience where users might think the site is broken or still loading if the post list is empty. Explicitly acknowledging the empty list provides clear guidance.
**Before/After:** The homepage previously showed the header and nothing underneath if there were no posts. Now it clearly states that no posts are available.
**Accessibility:** Provides clear context about the state of the content section.

---
*PR created automatically by Jules for task [12743132973163823874](https://jules.google.com/task/12743132973163823874) started by @tsainez*