### PR TITLE
🎨 Palette: Add home page empty state

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -47,3 +47,7 @@
 ## 2026-11-04 - Clear Escape Hatches
 **Learning:** When users hit a dead-end like a 404 page or an empty search results state, it can be frustrating and may lead to them abandoning the site.
 **Action:** Always provide a clear "escape hatch" in dead-end states, such as a prominent link back to the homepage or primary navigation area, to help users recover quickly.
+
+## 2026-06-17 - Empty State Escape Hatches
+**Learning:** When adding an empty state escape hatch to the homepage, linking back to the homepage (`/`) is redundant and circular.
+**Action:** Provide a relevant alternative link, such as the About page (`/about/`), to prevent circular navigation.

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -37,6 +37,11 @@ layout: default
     </ul>
 
     <p class="rss-subscribe">subscribe <a href="{{ "/feed.xml" | relative_url | escape }}">via RSS</a></p>
+  {%- else -%}
+    <div class="empty-state">
+      <p>No posts found.</p>
+      <p>Check back later or <a href="{{ '/about/' | relative_url | escape }}">read more about me</a>.</p>
+    </div>
   {%- endif -%}
 
 </div>


### PR DESCRIPTION
Added an empty state with a call-to-action on the homepage when there are no posts. Prevents a dead end for users if the blog has zero published posts.

---
*PR created automatically by Jules for task [16606228189392084826](https://jules.google.com/task/16606228189392084826) started by @tsainez*