### PR TITLE
⚡ Bolt: [performance improvement] Nokogiri HTML Serialization Avoidance

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -38,3 +38,7 @@
 ## 2025-05-24 - String Optimization Memory Allocations
 **Learning:** String mutation methods like `lstrip` create entirely new strings in memory. For massive HTML documents (e.g. `doc.output` in Jekyll hooks), this causes massive garbage collection overhead when executing repeatedly.
 **Action:** Replace operations like `raw_html.lstrip.start_with?("...")` with `raw_html.match?(/\A\s*(?:...)/i)`. The `match?` function evaluates string contents in-place and bypasses object instantiation.
+
+## 2026-05-26 - Nokogiri HTML Serialization Avoidance and Array Allocations
+**Learning:** In Jekyll `post_render` hooks using Nokogiri, serializing the DOM back to HTML with `page.to_html` is an extremely expensive operation. Doing it unconditionally, even when no nodes were altered, severely degrades build performance. Furthermore, parsing string attributes like `rel` by splitting into an array, appending, and joining (`rel.split(/\s+/)...join`) allocates multiple short-lived objects per iteration, leading to GC pressure.
+**Action:** Always wrap `page.to_html` (and `doc.output = ...`) in a conditional block (e.g., using a `modified` boolean flag) to only execute if the DOM was actually altered. When appending values to attribute strings inside tight loops, use simple concatenation and Regex checks (`match?`) instead of array manipulations to drastically cut down on object allocations.

--- a/_plugins/external_links.rb
+++ b/_plugins/external_links.rb
@@ -20,6 +20,8 @@ Jekyll::Hooks.register [:documents, :pages], :post_render do |doc|
     page = Nokogiri::HTML::DocumentFragment.parse(raw_html)
   end
 
+  modified = false
+
   page.xpath('descendant-or-self::a[translate(@target, "ABCDEFGHIJKLMNOPQRSTUVWXYZ", "abcdefghijklmnopqrstuvwxyz")="_blank"]').each do |link|
     href = link['href']
     next unless href
@@ -29,14 +31,19 @@ Jekyll::Hooks.register [:documents, :pages], :post_render do |doc|
     # instead of `strip =~` to avoid creating new string objects in memory.
     if href.match?(/\A\s*(?:https?:|\/\/)/i)
       rel = link['rel'] || ''
-      parts = rel.split(/\s+/)
+      original_rel = rel.dup
 
-      parts << 'noopener' unless parts.include?('noopener')
-      parts << 'noreferrer' unless parts.include?('noreferrer')
+      # ⚡ Bolt Optimization: Avoid string allocations from split and join
+      rel = rel.empty? ? 'noopener' : "#{rel} noopener" unless rel.match?(/(?:\A|\s)noopener(?:\s|\z)/i)
+      rel = rel.empty? ? 'noreferrer' : "#{rel} noreferrer" unless rel.match?(/(?:\A|\s)noreferrer(?:\s|\z)/i)
 
-      link['rel'] = parts.join(' ')
+      if rel != original_rel
+        link['rel'] = rel
+        modified = true
+      end
     end
   end
 
-  doc.output = page.to_html
+  # ⚡ Bolt Optimization: Only serialize DOM back to HTML if we actually modified it
+  doc.output = page.to_html if modified
 end


### PR DESCRIPTION
💡 **What**: Added a `modified` boolean check to skip `page.to_html` serialization if no DOM changes were made. Replaced `String#split` and `Array#join` with regex and string concatenation when modifying `rel` attributes.
🎯 **Why**: Nokogiri's `to_html` method is highly CPU intensive. Unconditionally serializing the DOM, even when it hasn't been altered, significantly impacts Jekyll's build times. Additionally, splitting strings into arrays within a tight `each` loop creates unnecessary, short-lived object allocations that put pressure on the Ruby Garbage Collector.
📊 **Impact**: Massive performance speedup during site regeneration for pages that contain targets but don't require external link manipulation, along with slightly lower memory utilization.
🔬 **Measurement**: Verified the Ruby hooks with the provided RSpec test suite (`bundle exec rake spec`) and ensured HTML Proofer generated no errors.

---
*PR created automatically by Jules for task [6316762292592645799](https://jules.google.com/task/6316762292592645799) started by @tsainez*