### PR TITLE
🎨 Palette: Improve skip-link accessibility with clip pattern

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -51,3 +51,7 @@
 ## 2026-06-17 - Empty State Escape Hatches
 **Learning:** When adding an empty state escape hatch to the homepage, linking back to the homepage (`/`) is redundant and circular.
 **Action:** Provide a relevant alternative link, such as the About page (`/about/`), to prevent circular navigation.
+
+## 2025-05-24 - Accessible Skip-to-Content Link
+**Learning:** Using `top: -9999px` to hide skip-to-content links can cause scrolling issues on RTL pages or with certain screen readers.
+**Action:** Always use the standard `clip` (visually hidden) pattern to hide skip links while keeping them in the accessibility tree, and explicitly add a visible `:focus` or `:focus-visible` state with `outline` to aid keyboard users.

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -49,22 +49,33 @@ $focus-color: #82aaff;
 /* Skip to content link - visually hidden but accessible */
 .skip-link {
   position: absolute;
-  top: -9999px;
-  left: -9999px;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+
   background: #000;
   color: #fff;
-  padding: 8px 16px;
   z-index: 100;
   text-decoration: none;
   font-weight: bold;
 
-  &:focus {
-    top: 0;
-    left: 0;
+  &:focus,
+  &:focus-visible {
+    position: static;
     width: auto;
     height: auto;
-    /* Using CSS clip pattern to hide it visually but keep it accessible */
+    padding: 8px 16px;
+    margin: 0;
+    overflow: visible;
     clip: auto;
+    white-space: normal;
+    outline: 2px solid $focus-color;
+    outline-offset: 2px;
   }
 }
 


### PR DESCRIPTION
**💡 What:** Replaced the outdated off-screen (`top: -9999px`) hiding method for the "Skip to content" link with the accessible `clip` pattern, and explicitly added `:focus-visible` outline styles.
**🎯 Why:** Hiding interactive elements completely off-screen can cause scrolling issues on some browsers, particularly for RTL text, and causes unpredictable behavior with some screen readers. The `clip` pattern keeps the element properly within the accessibility tree. Adding clear `:focus-visible` styles ensures a seamless experience for keyboard users when tabbing into the page.
**📸 Before/After:** The focus outline correctly displays when the hidden link receives keyboard focus.
**♿ Accessibility:** Enhanced skip-link predictability for screen readers and provided explicit, high-contrast visual focus indicators.

---
*PR created automatically by Jules for task [792151393703412460](https://jules.google.com/task/792151393703412460) started by @tsainez*