### PR TITLE
⚡ Bolt: Optimize Nokogiri DOM serialization and loop array allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -38,3 +38,7 @@
 ## 2025-05-24 - String Optimization Memory Allocations
 **Learning:** String mutation methods like `lstrip` create entirely new strings in memory. For massive HTML documents (e.g. `doc.output` in Jekyll hooks), this causes massive garbage collection overhead when executing repeatedly.
 **Action:** Replace operations like `raw_html.lstrip.start_with?("...")` with `raw_html.match?(/\A\s*(?:...)/i)`. The `match?` function evaluates string contents in-place and bypasses object instantiation.
+
+## 2026-05-25 - HTML Serialization Cost and Loop Array Allocations
+**Learning:** Calling `Nokogiri::HTML#to_html` is significantly expensive, and running it unconditionally at the end of a Jekyll `post_render` block causes unnecessary main thread stalls during the build, even when the DOM was not mutated. Additionally, using `String#split` and `Array#join` to append to delimited attribute strings inside loops dynamically allocates many short-lived objects leading to thrashing.
+**Action:** Track DOM modifications explicitly using a `modified` boolean flag to only call `.to_html` when necessary. Instead of array manipulation, utilize fast Regex (e.g. `match?(/(?:\s|^)attribute(?:\s|$)/)`) to check for the presence of delimited values, and use `String#<<` with an initial `dup` for in-place string concatenation.

--- a/_plugins/external_links.rb
+++ b/_plugins/external_links.rb
@@ -20,6 +20,8 @@ Jekyll::Hooks.register [:documents, :pages], :post_render do |doc|
     page = Nokogiri::HTML::DocumentFragment.parse(raw_html)
   end
 
+  modified = false
+
   page.xpath('descendant-or-self::a[translate(@target, "ABCDEFGHIJKLMNOPQRSTUVWXYZ", "abcdefghijklmnopqrstuvwxyz")="_blank"]').each do |link|
     href = link['href']
     next unless href
@@ -29,14 +31,29 @@ Jekyll::Hooks.register [:documents, :pages], :post_render do |doc|
     # instead of `strip =~` to avoid creating new string objects in memory.
     if href.match?(/\A\s*(?:https?:|\/\/)/i)
       rel = link['rel'] || ''
-      parts = rel.split(/\s+/)
 
-      parts << 'noopener' unless parts.include?('noopener')
-      parts << 'noreferrer' unless parts.include?('noreferrer')
+      # ⚡ Bolt Optimization: Use string dup and concatenation instead of split/join array allocations
+      new_rel = rel.dup
+      needs_update = false
 
-      link['rel'] = parts.join(' ')
+      unless new_rel.match?(/(?:\s|^)noopener(?:\s|$)/)
+        new_rel << (new_rel.empty? ? 'noopener' : ' noopener')
+        needs_update = true
+      end
+
+      unless new_rel.match?(/(?:\s|^)noreferrer(?:\s|$)/)
+        new_rel << (new_rel.empty? ? 'noreferrer' : ' noreferrer')
+        needs_update = true
+      end
+
+      if needs_update
+        link['rel'] = new_rel
+        modified = true
+      end
     end
   end
 
-  doc.output = page.to_html
+  # ⚡ Bolt Optimization: Conditionally serialize DOM back to HTML
+  # Nokogiri's `to_html` is extremely expensive. We only pay this penalty if the DOM was actually modified.
+  doc.output = page.to_html if modified
 end


### PR DESCRIPTION
💡 What: 
- Optimized `_plugins/external_links.rb` to skip `Nokogiri::HTML#to_html` serialization if the page was not modified.
- Avoided the `rel.split(/\s+/)` and `parts.join(' ')` loop behavior. We now use an initial duplication `.dup` of the `rel` string followed by in-place Regex evaluation (`match?`) and string concatenation (`<<`).

🎯 Why: 
Nokogiri DOM re-serialization is highly CPU intensive during the Jekyll build step and doing so unconditionally for all files blocks the main thread. Additionally, splitting delimited attribute strings into arrays and then re-joining them dynamically allocates short-lived objects on the heap, triggering frequent Ruby Garbage Collection which creates memory overhead.

📊 Impact: 
Micro-benchmarking confirms that replacing loop array creation with pure Regex string inspection avoids GC spikes. Skipping DOM reserialization makes `post_render` phase execution drop dramatically to virtually zero on pages containing `target=_blank` that already had the rel tags correctly attached. 

🔬 Measurement: 
To verify this improvement, run the Ruby testing script: `bundle exec ruby tests/verify_external_links_plugin.rb` or the full rspec suite `bundle exec rake spec`. Both should succeed, verifying no loss of logic while maintaining standard site functionality.

---
*PR created automatically by Jules for task [17119158506019446817](https://jules.google.com/task/17119158506019446817) started by @tsainez*