### PR TITLE
⚡ Bolt: [performance improvement] Skip Nokogiri DOM serialization when unmodified

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -38,3 +38,7 @@
 ## 2025-05-24 - String Optimization Memory Allocations
 **Learning:** String mutation methods like `lstrip` create entirely new strings in memory. For massive HTML documents (e.g. `doc.output` in Jekyll hooks), this causes massive garbage collection overhead when executing repeatedly.
 **Action:** Replace operations like `raw_html.lstrip.start_with?("...")` with `raw_html.match?(/\A\s*(?:...)/i)`. The `match?` function evaluates string contents in-place and bypasses object instantiation.
+
+## 2024-05-28 - Nokogiri Serialization Optimization
+**Learning:** In Jekyll `post_render` hooks using Nokogiri, unconditionally serializing the entire DOM tree back to an HTML string (`doc.output = page.to_html`) at the end of the hook is extremely expensive and significantly impacts build times, even if no nodes were actually modified.
+**Action:** Always track whether the DOM was actually modified (e.g., using a `modified` boolean flag) and wrap `doc.output = page.to_html` in a conditional block to skip serialization when the document remains unchanged.

--- a/_plugins/external_links.rb
+++ b/_plugins/external_links.rb
@@ -20,6 +20,8 @@ Jekyll::Hooks.register [:documents, :pages], :post_render do |doc|
     page = Nokogiri::HTML::DocumentFragment.parse(raw_html)
   end
 
+  modified = false
+
   page.xpath('descendant-or-self::a[translate(@target, "ABCDEFGHIJKLMNOPQRSTUVWXYZ", "abcdefghijklmnopqrstuvwxyz")="_blank"]').each do |link|
     href = link['href']
     next unless href
@@ -29,14 +31,26 @@ Jekyll::Hooks.register [:documents, :pages], :post_render do |doc|
     # instead of `strip =~` to avoid creating new string objects in memory.
     if href.match?(/\A\s*(?:https?:|\/\/)/i)
       rel = link['rel'] || ''
-      parts = rel.split(/\s+/)
 
-      parts << 'noopener' unless parts.include?('noopener')
-      parts << 'noreferrer' unless parts.include?('noreferrer')
+      # ⚡ Bolt Optimization: Avoid unnecessary string allocations using string interpolation
+      # and track modifications to avoid unconditional Nokogiri DOM serialization
+      original_rel = rel.dup
 
-      link['rel'] = parts.join(' ')
+      unless rel.match?(/(?:\s|^)noopener(?:\s|$)/)
+        rel = rel.empty? ? 'noopener' : "#{rel} noopener"
+      end
+      unless rel.match?(/(?:\s|^)noreferrer(?:\s|$)/)
+        rel = rel.empty? ? 'noreferrer' : "#{rel} noreferrer"
+      end
+
+      if original_rel != rel
+        link['rel'] = rel
+        modified = true
+      end
     end
   end
 
-  doc.output = page.to_html
+  # ⚡ Bolt Optimization: Only serialize DOM back to HTML if actually modified
+  # unconditionally calling page.to_html is an extremely expensive operation
+  doc.output = page.to_html if modified
 end


### PR DESCRIPTION
**What:** Optimized `_plugins/external_links.rb` to only call `page.to_html` if external links are actually modified. Uses string interpolation rather than array manipulations (`split`) to manage `rel` modifications.
**Why:** Unconditionally serializing the DOM tree back to an HTML string is a computationally expensive operation during Jekyll build time. Skipping this when no changes occur provides a substantial build speedup.
**Impact:** Avoids unnecessary Nokogiri string allocation and HTML generation for any files that have external links but already contain `noopener noreferrer`.
**Measurement:** Verify by running `bundle exec rake spec` to ensure build success, or use `Benchmark.bm` to profile Ruby execution times.

---
*PR created automatically by Jules for task [15124175652552320732](https://jules.google.com/task/15124175652552320732) started by @tsainez*