### PR TITLE
🎨 Palette: [accessibility improvement] Use clip pattern for skip link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __pycache__/
 node_modules/
 test-results/
 jekyll_serve.log
+jekyll_serve.log

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -51,3 +51,7 @@
 ## 2026-06-17 - Empty State Escape Hatches
 **Learning:** When adding an empty state escape hatch to the homepage, linking back to the homepage (`/`) is redundant and circular.
 **Action:** Provide a relevant alternative link, such as the About page (`/about/`), to prevent circular navigation.
+
+## 2026-06-21 - Skip Link Hidden State
+**Learning:** Hiding skip-to-content links using `top: -9999px` causes scrolling issues on RTL pages and can create unwanted focus jumps with screen readers.
+**Action:** Use the visually hidden `clip` pattern (`clip: rect(0, 0, 0, 0)` combined with `width: 1px` and `overflow: hidden`) and explicitly reset these properties on `:focus` and `:focus-visible` to ensure proper keyboard accessibility.

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -49,21 +49,31 @@ $focus-color: #82aaff;
 /* Skip to content link - visually hidden but accessible */
 .skip-link {
   position: absolute;
-  top: -9999px;
-  left: -9999px;
   background: #000;
   color: #fff;
-  padding: 8px 16px;
   z-index: 100;
   text-decoration: none;
   font-weight: bold;
 
-  &:focus {
+  /* Accessible visual hidden pattern */
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+
+  &:focus,
+  &:focus-visible {
     top: 0;
     left: 0;
     width: auto;
     height: auto;
-    /* Using CSS clip pattern to hide it visually but keep it accessible */
+    margin: 0;
+    padding: 8px 16px;
+    overflow: visible;
     clip: auto;
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,55 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.60.0
+        version: 1.61.0
+      playwright:
+        specifier: ^1.59.1
+        version: 1.61.0
+
+packages:
+
+  '@playwright/test@1.61.0':
+    resolution: {integrity: sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  playwright-core@1.61.0:
+    resolution: {integrity: sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.0:
+    resolution: {integrity: sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+snapshots:
+
+  '@playwright/test@1.61.0':
+    dependencies:
+      playwright: 1.61.0
+
+  fsevents@2.3.2:
+    optional: true
+
+  playwright-core@1.61.0: {}
+
+  playwright@1.61.0:
+    dependencies:
+      playwright-core: 1.61.0
+    optionalDependencies:
+      fsevents: 2.3.2


### PR DESCRIPTION
💡 **What:** Replaced the outdated `top: -9999px` hiding method for the `.skip-link` with the modern, accessible `clip` (visually hidden) pattern in `assets/main.scss`. Added robust reset properties to the `:focus-visible` state to ensure it renders correctly when focused.
🎯 **Why:** Hiding interactive elements by moving them thousands of pixels off-screen creates layout and scrolling issues, particularly in right-to-left (RTL) languages. It can also cause unwanted "jumps" when screen readers programmatically focus the element. The `clip` pattern safely hides the element visually while keeping it fully accessible to screen readers and keyboard users without disrupting layout.
📸 **Before/After:** The link remains visually hidden by default, and appears smoothly in the top left corner when Tab focus is triggered, matching the original intended behavior but without the underlying layout risks.
♿ **Accessibility:** Improves baseline keyboard and screen reader accessibility by ensuring focusable elements remain within the document flow and viewport boundaries.

---
*PR created automatically by Jules for task [4195133969901890558](https://jules.google.com/task/4195133969901890558) started by @tsainez*