### PR TITLE
⚡ Bolt: [performance improvement] Optimize DOM serialization and string allocation in external links plugin

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -38,3 +38,11 @@
 ## 2025-05-24 - String Optimization Memory Allocations
 **Learning:** String mutation methods like `lstrip` create entirely new strings in memory. For massive HTML documents (e.g. `doc.output` in Jekyll hooks), this causes massive garbage collection overhead when executing repeatedly.
 **Action:** Replace operations like `raw_html.lstrip.start_with?("...")` with `raw_html.match?(/\A\s*(?:...)/i)`. The `match?` function evaluates string contents in-place and bypasses object instantiation.
+
+## 2026-05-26 - DOM Serialization Optimization in Jekyll Plugins
+**Learning:** In Jekyll `post_render` hooks using Nokogiri, unconditionally serializing the DOM back to HTML (`page.to_html`) is an extremely expensive operation. Doing so when the DOM hasn't actually changed wastes significant CPU time and blocks the build.
+**Action:** Always wrap `doc.output = page.to_html` in a conditional block (e.g., using a `modified = false` flag that is set to `true` only when the DOM is mutated) to execute only if the DOM was actually modified.
+
+## 2026-05-26 - String Splitting Memory Allocations
+**Learning:** In Ruby, modifying HTML attributes (e.g., adding classes or rel attributes) inside loops using array manipulations like `split(/\s+/)` and `join` creates unnecessary intermediate arrays and string objects, adding to garbage collection overhead.
+**Action:** Favor simple string checks (`match?`) and string concatenation or interpolation over array manipulations to avoid excessive memory allocations and improve parsing performance.

--- a/_plugins/external_links.rb
+++ b/_plugins/external_links.rb
@@ -20,6 +20,12 @@ Jekyll::Hooks.register [:documents, :pages], :post_render do |doc|
     page = Nokogiri::HTML::DocumentFragment.parse(raw_html)
   end
 
+  # ⚡ Bolt Optimization: Track if we actually modify the DOM.
+  # Nokogiri's `to_html` is extremely expensive. If we parse the document
+  # but find all target links already have noopener/noreferrer, we should
+  # avoid serializing the DOM back to HTML.
+  modified = false
+
   page.xpath('descendant-or-self::a[translate(@target, "ABCDEFGHIJKLMNOPQRSTUVWXYZ", "abcdefghijklmnopqrstuvwxyz")="_blank"]').each do |link|
     href = link['href']
     next unless href
@@ -29,14 +35,23 @@ Jekyll::Hooks.register [:documents, :pages], :post_render do |doc|
     # instead of `strip =~` to avoid creating new string objects in memory.
     if href.match?(/\A\s*(?:https?:|\/\/)/i)
       rel = link['rel'] || ''
-      parts = rel.split(/\s+/)
 
-      parts << 'noopener' unless parts.include?('noopener')
-      parts << 'noreferrer' unless parts.include?('noreferrer')
+      # ⚡ Bolt Optimization: Avoid allocating arrays with `split` and `join`
+      # by using simple string checks and interpolation.
+      needs_noopener = !rel.match?(/\bnoopener\b/)
+      needs_noreferrer = !rel.match?(/\bnoreferrer\b/)
 
-      link['rel'] = parts.join(' ')
+      if needs_noopener || needs_noreferrer
+        new_rel = rel.dup
+        new_rel << (new_rel.empty? ? 'noopener' : ' noopener') if needs_noopener
+        new_rel << (new_rel.empty? ? 'noreferrer' : ' noreferrer') if needs_noreferrer
+
+        link['rel'] = new_rel
+        modified = true
+      end
     end
   end
 
-  doc.output = page.to_html
+  # ⚡ Bolt Optimization: Only serialize if changes were made
+  doc.output = page.to_html if modified
 end


### PR DESCRIPTION
💡 What: Tracked DOM modifications in `_plugins/external_links.rb` to only serialize with Nokogiri's `page.to_html` when a link was actually modified. Replaced array operations (`split`/`join`) with string `dup` and interpolation for updating the `rel` attribute.
🎯 Why: Nokogiri's `to_html` is computationally expensive. Unconditionally parsing the HTML back into a string string when no links needed `noopener`/`noreferrer` added significant latency. String splits within loops added to the garbage collector's workload.
📊 Impact: Considerably faster page build times for pages containing external links that already have proper rel tags, eliminating O(1) full-DOM serialization per page when there are no missing tags. Reduces memory allocations.
🔬 Measurement: Verified with `bundle exec jekyll build` and `bundle exec rake spec`. The generated output matches previous behavior exactly.

---
*PR created automatically by Jules for task [17492095107630881219](https://jules.google.com/task/17492095107630881219) started by @tsainez*