### PR TITLE
🎨 Palette: [UX improvement] Enhance skip-link accessibility with proper visual hiding

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -51,3 +51,7 @@
 ## 2026-06-17 - Empty State Escape Hatches
 **Learning:** When adding an empty state escape hatch to the homepage, linking back to the homepage (`/`) is redundant and circular.
 **Action:** Provide a relevant alternative link, such as the About page (`/about/`), to prevent circular navigation.
+
+## 2025-05-24 - Visually Hiding Elements Responsibly
+**Learning:** Hiding elements like skip-links using `top: -9999px` causes scrolling issues on RTL (Right-to-Left) pages and can occasionally break layout calculations or create focus tracking issues for screen readers.
+**Action:** Always use the `clip: rect(0, 0, 0, 0)` pattern (combined with `width: 1px`, `height: 1px`, `overflow: hidden`) to hide interactive elements visually while keeping them in the accessibility tree, and restore visibility using `:focus-visible`.

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -49,22 +49,30 @@ $focus-color: #82aaff;
 /* Skip to content link - visually hidden but accessible */
 .skip-link {
   position: absolute;
-  top: -9999px;
-  left: -9999px;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
   background: #000;
   color: #fff;
-  padding: 8px 16px;
   z-index: 100;
   text-decoration: none;
   font-weight: bold;
 
-  &:focus {
-    top: 0;
-    left: 0;
+  &:focus-visible {
     width: auto;
     height: auto;
-    /* Using CSS clip pattern to hide it visually but keep it accessible */
+    padding: 8px 16px;
+    margin: 0;
+    overflow: visible;
     clip: auto;
+    white-space: normal;
+    top: 0;
+    left: 0;
   }
 }
 


### PR DESCRIPTION
💡 **What:** Replaced the legacy `top: -9999px` method for visually hiding the "Skip to main content" link with the modern `clip` pattern.
🎯 **Why:** Hiding elements off-screen using `-9999px` can cause horizontal scrollbar issues on RTL (right-to-left) layouts and occasionally causes screen readers to lose focus tracking. The `clip` pattern is the robust, widely accepted standard for `.sr-only` utility classes.
📸 **Before/After:** The visual experience remains the same—the link is hidden until focused via the `Tab` key, at which point it uses `:focus-visible` to appear smoothly.
♿ **Accessibility:** Ensures the skip-link remains reliably in the accessibility tree without layout side effects.

---
*PR created automatically by Jules for task [11267501689732371684](https://jules.google.com/task/11267501689732371684) started by @tsainez*