### PR TITLE
⚡ Bolt: [performance improvement] Optimize Nokogiri serialization and reduce memory allocations in post_render hook

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -38,3 +38,11 @@
 ## 2025-05-24 - String Optimization Memory Allocations
 **Learning:** String mutation methods like `lstrip` create entirely new strings in memory. For massive HTML documents (e.g. `doc.output` in Jekyll hooks), this causes massive garbage collection overhead when executing repeatedly.
 **Action:** Replace operations like `raw_html.lstrip.start_with?("...")` with `raw_html.match?(/\A\s*(?:...)/i)`. The `match?` function evaluates string contents in-place and bypasses object instantiation.
+
+## 2026-05-26 - Unconditional Nokogiri Serialization
+**Learning:** In Jekyll post_render hooks that use Nokogiri to manipulate the DOM, unconditionally calling `page.to_html` to serialize the DOM back into a string is extremely expensive. If the DOM was parsed but not actually modified, this serialization wastes massive amounts of CPU time, severely degrading build performance for large sites.
+**Action:** Always wrap DOM serialization (like `doc.output = page.to_html`) in a conditional block (using a `modified` boolean flag) so it only executes when the DOM has actually been changed.
+
+## 2026-05-26 - Ruby Array Allocation in Loops
+**Learning:** Using array manipulation methods like `split` and `join` inside iterative loops to modify HTML attributes (e.g., adding classes or rels) causes significant memory allocation and garbage collection overhead, especially when parsing many elements.
+**Action:** Replace array-based manipulations in loops with simple regex checks (`match?`) and string concatenation (`dup` and `<<`) to evaluate and update strings with minimal object instantiation.

--- a/_plugins/external_links.rb
+++ b/_plugins/external_links.rb
@@ -20,6 +20,8 @@ Jekyll::Hooks.register [:documents, :pages], :post_render do |doc|
     page = Nokogiri::HTML::DocumentFragment.parse(raw_html)
   end
 
+  modified = false
+
   page.xpath('descendant-or-self::a[translate(@target, "ABCDEFGHIJKLMNOPQRSTUVWXYZ", "abcdefghijklmnopqrstuvwxyz")="_blank"]').each do |link|
     href = link['href']
     next unless href
@@ -29,14 +31,24 @@ Jekyll::Hooks.register [:documents, :pages], :post_render do |doc|
     # instead of `strip =~` to avoid creating new string objects in memory.
     if href.match?(/\A\s*(?:https?:|\/\/)/i)
       rel = link['rel'] || ''
-      parts = rel.split(/\s+/)
 
-      parts << 'noopener' unless parts.include?('noopener')
-      parts << 'noreferrer' unless parts.include?('noreferrer')
+      # ⚡ Bolt Optimization: Replace `split` and `join` array manipulation
+      # with simple regex and string concatenation to avoid allocating arrays and strings
+      # inside loops for better performance.
+      needs_noopener = !rel.match?(/\bnoopener\b/)
+      needs_noreferrer = !rel.match?(/\bnoreferrer\b/)
 
-      link['rel'] = parts.join(' ')
+      if needs_noopener || needs_noreferrer
+        new_rel = rel.dup
+        new_rel << ' noopener' if needs_noopener
+        new_rel << ' noreferrer' if needs_noreferrer
+        link['rel'] = new_rel.strip
+        modified = true
+      end
     end
   end
 
-  doc.output = page.to_html
+  # ⚡ Bolt Optimization: Only serialize DOM to HTML if modifications were actually made
+  # unconditional serialization is incredibly expensive on large pages
+  doc.output = page.to_html if modified
 end


### PR DESCRIPTION
⚡ Bolt: [performance improvement] Optimize Nokogiri serialization and reduce memory allocations in post_render hook

💡 What:
1. Conditionally serialize the DOM (`page.to_html`) only if `modified` is true.
2. Replace array manipulations (`split`, `join`) with simple regex checks (`match?`) and string concatenations (`dup`, `<<`) for updating the `rel` attribute.

🎯 Why: Unconditional serialization of the DOM back to a string wastes massive amounts of CPU time when parsing large files that do not actually require any modifications. Furthermore, allocating and throwing away arrays and strings inside loops adds significant garbage collection overhead during Jekyll's site build.

📊 Impact: Massively reduces CPU time and memory allocations during Jekyll's `post_render` phase, leading to significantly faster site builds, particularly for large pages or sites with many pages.

🔬 Measurement: Run Jekyll builds with and without the patch on large sites, profiling memory usage and CPU time during the `post_render` hooks.

---
*PR created automatically by Jules for task [11241889284628035836](https://jules.google.com/task/11241889284628035836) started by @tsainez*