### PR TITLE
🎨 Palette: Improve skip link accessibility with clip pattern

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -51,3 +51,6 @@
 ## 2026-06-17 - Empty State Escape Hatches
 **Learning:** When adding an empty state escape hatch to the homepage, linking back to the homepage (`/`) is redundant and circular.
 **Action:** Provide a relevant alternative link, such as the About page (`/about/`), to prevent circular navigation.
+## 2026-11-10 - Skip Link Visually Hidden Pattern
+**Learning:** When hiding skip-to-content links, using `top: -9999px` or `left: -9999px` can cause unintended scrolling issues, particularly on RTL (right-to-left) pages or when screen readers attempt to scroll to the focused element before the CSS `:focus` state fully applies. This creates a jarring user experience.
+**Action:** Instead, use the visually hidden `clip` pattern (`clip: rect(0, 0, 0, 0)` combined with `width: 1px; height: 1px; overflow: hidden`) and explicitly reset these properties on `:focus` or `:focus-visible` to ensure the link remains fully accessible to screen readers and keyboard users without causing layout side effects.

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -49,11 +49,16 @@ $focus-color: #82aaff;
 /* Skip to content link - visually hidden but accessible */
 .skip-link {
   position: absolute;
-  top: -9999px;
-  left: -9999px;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
   background: #000;
   color: #fff;
-  padding: 8px 16px;
   z-index: 100;
   text-decoration: none;
   font-weight: bold;
@@ -63,8 +68,11 @@ $focus-color: #82aaff;
     left: 0;
     width: auto;
     height: auto;
-    /* Using CSS clip pattern to hide it visually but keep it accessible */
+    margin: 0;
+    padding: 8px 16px;
+    overflow: visible;
     clip: auto;
+    white-space: normal;
   }
 }
 


### PR DESCRIPTION
💡 **What:** Replaced the `top: -9999px` and `left: -9999px` off-screen positioning for the skip-to-content link with the standard `clip: rect(0, 0, 0, 0)` visually hidden pattern.
🎯 **Why:** Moving elements far off-screen can cause unintended scrolling behavior and layout bugs, particularly on RTL (right-to-left) pages, or when screen readers focus the link *before* the browser applies the `:focus` pseudo-class styles that bring it back on-screen. 
📸 **Before/After:** The link remains visually hidden initially and becomes visible and focused when the user presses `Tab`.
♿ **Accessibility:** This ensures a smoother, more robust experience for keyboard and screen reader users, preventing jarring scrolling jumps.

---
*PR created automatically by Jules for task [17362363599431501785](https://jules.google.com/task/17362363599431501785) started by @tsainez*