### PR TITLE
⚡ Bolt: [performance improvement] Prevent unconditional DOM serialization in Nokogiri hook

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -38,3 +38,7 @@
 ## 2025-05-24 - String Optimization Memory Allocations
 **Learning:** String mutation methods like `lstrip` create entirely new strings in memory. For massive HTML documents (e.g. `doc.output` in Jekyll hooks), this causes massive garbage collection overhead when executing repeatedly.
 **Action:** Replace operations like `raw_html.lstrip.start_with?("...")` with `raw_html.match?(/\A\s*(?:...)/i)`. The `match?` function evaluates string contents in-place and bypasses object instantiation.
+
+## 2026-05-26 - Unconditional DOM Serialization in Jekyll Plugins
+**Learning:** In Jekyll `post_render` hooks using Nokogiri, unconditionally serializing the DOM back to HTML (`page.to_html`) is an extremely expensive operation that allocates massive amounts of memory, even if no elements were actually modified in the DOM tree. This unnecessarily blocks the build.
+**Action:** Always wrap `page.to_html` (or similar serialization methods) in a conditional block governed by a `modified` boolean flag. Set this flag only when actual modifications are made to the DOM to skip serialization entirely when there's no change.

--- a/_plugins/external_links.rb
+++ b/_plugins/external_links.rb
@@ -20,6 +20,8 @@ Jekyll::Hooks.register [:documents, :pages], :post_render do |doc|
     page = Nokogiri::HTML::DocumentFragment.parse(raw_html)
   end
 
+  modified = false
+
   page.xpath('descendant-or-self::a[translate(@target, "ABCDEFGHIJKLMNOPQRSTUVWXYZ", "abcdefghijklmnopqrstuvwxyz")="_blank"]').each do |link|
     href = link['href']
     next unless href
@@ -31,12 +33,18 @@ Jekyll::Hooks.register [:documents, :pages], :post_render do |doc|
       rel = link['rel'] || ''
       parts = rel.split(/\s+/)
 
-      parts << 'noopener' unless parts.include?('noopener')
-      parts << 'noreferrer' unless parts.include?('noreferrer')
+      unless parts.include?('noopener') && parts.include?('noreferrer')
+        parts << 'noopener' unless parts.include?('noopener')
+        parts << 'noreferrer' unless parts.include?('noreferrer')
 
-      link['rel'] = parts.join(' ')
+        link['rel'] = parts.join(' ')
+        modified = true
+      end
     end
   end
 
-  doc.output = page.to_html
+  # ⚡ Bolt Optimization: Only serialize the DOM back to HTML if we actually modified it.
+  # Unconditionally calling `page.to_html` is an extremely expensive operation and forces
+  # massive string allocations, which wastes time when nothing was changed.
+  doc.output = page.to_html if modified
 end


### PR DESCRIPTION
What:
Modified `_plugins/external_links.rb` to only run the expensive `page.to_html` serialization if a link tag was actually modified with noopener or noreferrer.

Why:
Parsing a document with Nokogiri and writing it back to an HTML string unconditionally is a highly expensive operation that forces significant memory allocations. If the user doesn't modify anything on the page, the serializion step is entirely unnecessary. 

Impact:
Provides significant speedups to page generations, saving time during Jekyll builds while leaving original HTML strings perfectly unmodified if there are no external links.

Measurement:
Can be verified by viewing generated output in `_site` directories and running benchmark analyses on build times.

---
*PR created automatically by Jules for task [12816931450559824234](https://jules.google.com/task/12816931450559824234) started by @tsainez*