### PR TITLE
🎨 Palette: [UX improvement] Hide skip-to-content link accessibly using clip pattern

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -51,3 +51,7 @@
 ## 2026-06-17 - Empty State Escape Hatches
 **Learning:** When adding an empty state escape hatch to the homepage, linking back to the homepage (`/`) is redundant and circular.
 **Action:** Provide a relevant alternative link, such as the About page (`/about/`), to prevent circular navigation.
+
+## 2026-11-05 - Hiding Skip Links Accessibly
+**Learning:** Hiding skip-to-content links using `top: -9999px` causes scrolling issues on right-to-left (RTL) pages or when using screen readers, and can sometimes result in layout glitches. The element should be visually hidden but still exist naturally in the accessibility tree without being shifted thousands of pixels away.
+**Action:** Always use the visually hidden `clip` pattern (`clip: rect(0, 0, 0, 0)`, `width: 1px`, `height: 1px`, `overflow: hidden`, `white-space: nowrap`) to hide interactive elements like skip links. Use `:focus-visible` to restore the visual properties (`width: auto`, `clip: auto`, etc.) when the element receives keyboard focus.

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -49,22 +49,30 @@ $focus-color: #82aaff;
 /* Skip to content link - visually hidden but accessible */
 .skip-link {
   position: absolute;
-  top: -9999px;
-  left: -9999px;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
   background: #000;
   color: #fff;
-  padding: 8px 16px;
   z-index: 100;
   text-decoration: none;
   font-weight: bold;
 
-  &:focus {
-    top: 0;
-    left: 0;
+  &:focus-visible {
     width: auto;
     height: auto;
-    /* Using CSS clip pattern to hide it visually but keep it accessible */
+    padding: 8px 16px;
+    margin: 0;
+    overflow: visible;
     clip: auto;
+    white-space: normal;
+    top: 0;
+    left: 0;
   }
 }
 


### PR DESCRIPTION
💡 **What**: Refactored the `.skip-link` CSS class to use the visually hidden `clip` pattern (`clip: rect(0, 0, 0, 0)`) instead of positioning it off-screen with `top: -9999px`. Restored visual properties on `:focus-visible`.
🎯 **Why**: Using `top: -9999px` to hide skip links creates an artificially massive layout height, which causes severe scrolling bugs on right-to-left (RTL) pages and can sometimes disrupt screen reader traversal or trigger layout glitches. The `clip` pattern correctly hides it visually while leaving it positioned naturally in the DOM for screen readers to access.
📸 **Before/After**: The visual focus state remains identical (black box with white text at the top-left), but it now functions correctly across more screen reader and layout configurations.
♿ **Accessibility**: Prevents edge-case scrolling layout issues for screen reader users and improves general structural soundness by keeping focusable elements within standard viewport boundaries before activation.

---
*PR created automatically by Jules for task [3063263364488455899](https://jules.google.com/task/3063263364488455899) started by @tsainez*