### PR TITLE
⚡ Bolt: [performance improvement] Optimize external links plugin string allocations and DOM serialization

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -38,3 +38,11 @@
 ## 2025-05-24 - String Optimization Memory Allocations
 **Learning:** String mutation methods like `lstrip` create entirely new strings in memory. For massive HTML documents (e.g. `doc.output` in Jekyll hooks), this causes massive garbage collection overhead when executing repeatedly.
 **Action:** Replace operations like `raw_html.lstrip.start_with?("...")` with `raw_html.match?(/\A\s*(?:...)/i)`. The `match?` function evaluates string contents in-place and bypasses object instantiation.
+
+## 2026-05-26 - Ruby Array Allocation Thrashing in Loops
+**Learning:** Using `split(/\s+/)` and `join(' ')` to manipulate HTML attributes (like `rel`) inside Ruby loops creates unnecessary array objects and intermediate strings, leading to excessive memory allocation and garbage collection overhead.
+**Action:** When modifying string-based HTML attributes, favor simple string interpolation (`"#{rel} noopener"`) and regex matching (`rel.match?(/(?:\s|\A)noopener(?:\s|\z)/)`) to avoid array allocations and improve parsing performance.
+
+## 2026-05-26 - Unconditional DOM Serialization Overhead
+**Learning:** In Nokogiri `post_render` hooks, unconditionally calling `page.to_html` to serialize the DOM back into a string is an extremely expensive operation, even if no modifications were actually made to the parsed DOM tree.
+**Action:** Always wrap DOM serialization in a conditional block (e.g., using a `modified` boolean flag) to ensure `page.to_html` is executed only if the DOM was actually altered, significantly reducing unnecessary processing overhead.

--- a/_plugins/external_links.rb
+++ b/_plugins/external_links.rb
@@ -20,6 +20,8 @@ Jekyll::Hooks.register [:documents, :pages], :post_render do |doc|
     page = Nokogiri::HTML::DocumentFragment.parse(raw_html)
   end
 
+  modified = false
+
   page.xpath('descendant-or-self::a[translate(@target, "ABCDEFGHIJKLMNOPQRSTUVWXYZ", "abcdefghijklmnopqrstuvwxyz")="_blank"]').each do |link|
     href = link['href']
     next unless href
@@ -29,14 +31,28 @@ Jekyll::Hooks.register [:documents, :pages], :post_render do |doc|
     # instead of `strip =~` to avoid creating new string objects in memory.
     if href.match?(/\A\s*(?:https?:|\/\/)/i)
       rel = link['rel'] || ''
-      parts = rel.split(/\s+/)
+      link_modified = false
 
-      parts << 'noopener' unless parts.include?('noopener')
-      parts << 'noreferrer' unless parts.include?('noreferrer')
+      # ⚡ Bolt Optimization: Use regex and string interpolation instead of split/join
+      # to avoid unnecessary array allocations inside loops.
+      unless rel.match?(/(?:\s|\A)noopener(?:\s|\z)/i)
+        rel = rel.empty? ? 'noopener' : "#{rel} noopener"
+        link_modified = true
+      end
 
-      link['rel'] = parts.join(' ')
+      unless rel.match?(/(?:\s|\A)noreferrer(?:\s|\z)/i)
+        rel = rel.empty? ? 'noreferrer' : "#{rel} noreferrer"
+        link_modified = true
+      end
+
+      if link_modified
+        link['rel'] = rel
+        modified = true
+      end
     end
   end
 
-  doc.output = page.to_html
+  # ⚡ Bolt Optimization: Only serialize the DOM back to HTML if we actually modified it.
+  # Nokogiri's to_html is extremely expensive.
+  doc.output = page.to_html if modified
 end


### PR DESCRIPTION
💡 What: Optimized the Nokogiri `post_render` hook in `_plugins/external_links.rb` by using string interpolation instead of array allocations, and bypassing the expensive `page.to_html` serialization when no actual modifications are made.
🎯 Why: Nokogiri's `to_html` is notoriously expensive, and `split`/`join` operations inside loops create substantial garbage collection overhead, particularly for statically generated sites processing many documents.
📊 Impact: Considerably reduces memory allocation thrashing during `post_render` and avoids costly and unnecessary HTML DOM serializations for pages that do not have their links modified, improving overall build time.
🔬 Measurement: Verify correctness by ensuring that `bundle exec ruby tests/verify_external_links_plugin.rb` and the full `bundle exec rake spec` test suite pass with no regressions.

---
*PR created automatically by Jules for task [8908781134118098641](https://jules.google.com/task/8908781134118098641) started by @tsainez*