### PR TITLE
🎨 Palette: [UX improvement] Improve skip-link accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -51,3 +51,7 @@
 ## 2026-06-17 - Empty State Escape Hatches
 **Learning:** When adding an empty state escape hatch to the homepage, linking back to the homepage (`/`) is redundant and circular.
 **Action:** Provide a relevant alternative link, such as the About page (`/about/`), to prevent circular navigation.
+
+## 2026-11-10 - Skip Link Position Issues
+**Learning:** When hiding skip-to-content links, using `top: -9999px` causes scrolling issues on RTL (Right-To-Left) pages and can create unexpected behavior with screen readers. It physically moves the element far off-screen, which can sometimes extend scroll boundaries or cause layout glitches when focused.
+**Action:** Instead of `top: -9999px`, use the visually hidden `clip` pattern (`clip: rect(0, 0, 0, 0)`) combined with `:focus-visible` styles to ensure it remains in the accessibility tree without taking up visual space until focused by a keyboard.

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -49,22 +49,27 @@ $focus-color: #82aaff;
 /* Skip to content link - visually hidden but accessible */
 .skip-link {
   position: absolute;
-  top: -9999px;
-  left: -9999px;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
   background: #000;
   color: #fff;
-  padding: 8px 16px;
   z-index: 100;
   text-decoration: none;
   font-weight: bold;
 
-  &:focus {
-    top: 0;
-    left: 0;
+  &:focus-visible {
     width: auto;
     height: auto;
-    /* Using CSS clip pattern to hide it visually but keep it accessible */
+    margin: 0;
+    overflow: visible;
     clip: auto;
+    white-space: normal;
+    padding: 8px 16px;
   }
 }
 


### PR DESCRIPTION
💡 What: Updated `.skip-link` in `assets/main.scss` to use the visually hidden `clip` pattern (`clip: rect(0, 0, 0, 0)`) instead of `top: -9999px`, and updated the focus state to `:focus-visible`. Added a journal entry detailing the learning.
🎯 Why: Using `top: -9999px` to hide elements can cause scrolling issues on Right-To-Left (RTL) pages and unexpected behavior with screen readers. The `clip` pattern is the modern standard for visually hiding elements while keeping them in the accessibility tree.
📸 Before/After: Verified via Playwright screenshot; skip link correctly appears when focused via keyboard navigation.
♿ Accessibility: Ensures the skip-to-content link remains fully accessible to screen readers and keyboard users without causing layout issues or extending scroll boundaries.

---
*PR created automatically by Jules for task [7165050657922291017](https://jules.google.com/task/7165050657922291017) started by @tsainez*