### PR TITLE
🎨 Palette: Improve skip-to-content link accessibility

### DIFF
--- a/assets/main.scss
+++ b/assets/main.scss
@@ -49,22 +49,29 @@ $focus-color: #82aaff;
 /* Skip to content link - visually hidden but accessible */
 .skip-link {
   position: absolute;
-  top: -9999px;
-  left: -9999px;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 8px 16px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
   background: #000;
   color: #fff;
-  padding: 8px 16px;
   z-index: 100;
   text-decoration: none;
   font-weight: bold;
 
-  &:focus {
-    top: 0;
-    left: 0;
+  &:focus-visible {
     width: auto;
     height: auto;
-    /* Using CSS clip pattern to hide it visually but keep it accessible */
+    margin: 0;
+    overflow: visible;
     clip: auto;
+    top: 0;
+    left: 0;
+    outline: 2px solid $focus-color;
+    outline-offset: 2px;
   }
 }
 


### PR DESCRIPTION
**💡 What**:
Replaced the outdated `top: -9999px; left: -9999px` CSS pattern for the `.skip-link` with a modern visually hidden (`clip: rect(0, 0, 0, 0)`) pattern. Also updated the focus state to use `:focus-visible` with a distinct `outline`.

**🎯 Why**: 
The old `-9999px` hack is known to cause scroll jumping and odd focus behaviors on RTL pages or with certain screen readers. It takes the element fully out of normal flow in a way that breaks context for some assistive tech. 

**♿ Accessibility**:
The new approach ensures the skip-to-content link remains completely accessible to screen readers at all times, doesn't mess with page layout, and cleanly visualizes only when a user navigates to it via keyboard using modern `:focus-visible` techniques.

---
*PR created automatically by Jules for task [4761969420070369554](https://jules.google.com/task/4761969420070369554) started by @tsainez*