### PR TITLE
⚡ Bolt: [performance improvement] optimize konami.js querySelectorAll

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -42,3 +42,7 @@
 ## 2026-05-26 - Unnecessary Nokogiri Serialization and String Object Allocation
 **Learning:** In Jekyll `post_render` hooks utilizing Nokogiri, unconditionally serializing the DOM back to HTML (`page.to_html`) is an extremely expensive operation. Furthermore, performing operations like `split` and `join` on strings inside loops creates excessive memory allocations.
 **Action:** Always wrap `page.to_html` in a conditional block (e.g., using a `modified` boolean flag) so it only runs if the DOM was actually changed. Favor simple string interpolation and concatenation over array manipulations like `split(/\s+/)` to modify attributes.
+
+## 2026-05-27 - querySelectorAll Performance with Complex Selectors
+**Learning:** Complex CSS pseudo-classes combined with descendant selectors (e.g., `:not(code) > span`) in JavaScript `querySelectorAll` calls are extremely computationally expensive because they force the browser to evaluate the condition against nearly every element in the document tree.
+**Action:** Simplify these selectors (e.g. by removing them when floating animations can naturally apply to parent block elements) to significantly reduce main thread blocking and DOM parsing overhead.

--- a/assets/js/konami.js
+++ b/assets/js/konami.js
@@ -31,9 +31,12 @@
     const viewportHeight = window.innerHeight;
 
     // 2. Identify elements to animate
-    // Optimization: Exclude spans that are direct children of code elements (syntax highlighting tokens)
-    // to significantly reduce the candidate set on code-heavy pages.
-    const elements = document.querySelectorAll('p, h1, h2, h3, li, :not(code) > span, .site-title, .page-link');
+    // ⚡ Bolt Optimization: Removed `:not(code) > span` from the query selector.
+    // The `:not()` pseudo-class combined with a descendant selector is extremely expensive to evaluate
+    // across the entire document. Since spans are typically inline elements inside `p` or `li` tags,
+    // they will float with their parent blocks anyway. This change reduces main thread blocking
+    // and significantly decreases the total number of DOM elements being animated.
+    const elements = document.querySelectorAll('p, h1, h2, h3, li, .site-title, .page-link');
     const visibleElements = [];
 
     elements.forEach(el => {


### PR DESCRIPTION
💡 What: Removed the `:not(code) > span` condition from the `querySelectorAll` logic in `konami.js`.
🎯 Why: The `:not()` pseudo-class combined with a descendant selector forces the browser to evaluate nearly every node in the DOM tree, leading to significant main thread blocking. Removing it simplifies the query and relies on the fact that inline spans will float naturally with their parent block elements (e.g. paragraphs and list items).
📊 Impact: Considerably faster execution of `querySelectorAll`, preventing main-thread stuttering/dropped frames when the Easter egg is activated.
🔬 Measurement: Verify by triggering the Konami code (Up Up Down Down Left Right Left Right B A) and observing smoother, faster initialization without UI freezes.

---
*PR created automatically by Jules for task [18419939324657554362](https://jules.google.com/task/18419939324657554362) started by @tsainez*