### PR TITLE
🧪 [testing improvement] Add error path tests for external_links.rb

### DIFF
--- a/tests/verify_external_links_plugin.rb
+++ b/tests/verify_external_links_plugin.rb
@@ -53,3 +53,10 @@ test("Internal Link", '<a href="/internal" target="_blank">Link</a>', false)
 test("Existing Rel", '<a href="https://google.com" target="_blank" rel="nofollow">Link</a>', true)
 test("Case Insensitive Target", '<a href="https://example.com" target="_BLANK">Link</a>', true)
 test("Mixed Case Target", '<a href="https://example.com" target="_Blank">Link</a>', true)
+
+puts "--- Verifying Error Paths and Edge Cases ---"
+test("Malformed HTML (unclosed tag)", '<a href="https://example.com" target="_blank" <p>', true)
+test("Missing Quotes", '<a href=https://example.com target=_blank>Link</a>', true)
+test("Garbage Input Before Tag", '<<<<<<<<<<<<<<<<<<a href="https://example.com" target="_blank">', true)
+test("Missing Href", '<a target="_blank">Link</a>', false)
+test("Empty Href", '<a href="" target="_blank">Link</a>', false)


### PR DESCRIPTION
🎯 **What:** Added tests for malformed HTML, missing quotes, garbage input, and empty/missing hrefs to `tests/verify_external_links_plugin.rb` to ensure the plugin doesn't crash on unusual inputs.

📊 **Coverage:** Now tests Nokogiri parsing of unclosed tags, attributes missing quotes, arbitrary preceding garbage text, and edge cases where `href` is empty or completely missing.

✨ **Result:** Confirmed the plugin handles these edge cases safely without fatally crashing the build process, improving the reliability and safety net of the application.

---
*PR created automatically by Jules for task [17617656330689087085](https://jules.google.com/task/17617656330689087085) started by @tsainez*