### PR TITLE
🔒 Sentinel: [CRITICAL] Fix frame busting clickjacking bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -77,3 +77,8 @@
 **Vulnerability:** The external links plugin relied on Nokogiri's `a[target="_blank"]` CSS selector, which is strictly case-sensitive. This meant links authored with `target="_BLANK"` bypassed the filter and were not assigned `rel="noopener noreferrer"`, leaving them vulnerable to reverse tabnabbing.
 **Learning:** HTML attribute values like `target` are often treated case-insensitively by browsers but are evaluated strictly by parser selectors unless specifically configured. In Nokogiri, CSS selectors are case-sensitive.
 **Prevention:** Replaced the CSS selector with an XPath query using the `translate()` function to enforce case-insensitive matching (`//a[translate(@target, "ABCDEFGHIJKLMNOPQRSTUVWXYZ", "abcdefghijklmnopqrstuvwxyz")="_blank"]`), ensuring consistent and robust protection regardless of authored case.
+
+## 2026-07-18 - Frame Busting Clickjacking Bypass
+**Vulnerability:** The client-side frame-busting logic in `security.js` attempted to hide the page by manipulating the DOM (`document.documentElement.innerHTML = ''`), which relies on scripts executing. If an attacker frames the site in an iframe using the `sandbox` attribute (e.g., `sandbox="allow-forms"` without `allow-scripts`), the script doesn't execute and the site renders normally, exposing it to clickjacking.
+**Learning:** Security controls that rely on JavaScript execution fail closed (insecurely) if scripts are disabled or blocked by sandboxing.
+**Prevention:** Implement the OWASP-recommended frame-busting mechanism: securely hide the body by default using an inline CSS style (`<style id="antiClickjack">body{display:none !important;}</style>`), allow this style through CSP using a SHA-256 hash, and only remove it via JavaScript if `window.self === window.top`.

--- a/_includes/csp.html
+++ b/_includes/csp.html
@@ -1,2 +1,2 @@
 <!-- Note: 'unsafe-inline' removed from script-src and style-src for security. -->
-<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self'; base-uri 'self'; object-src 'none'; frame-src 'none'; form-action 'none'; upgrade-insecure-requests;">
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'sha256-+p6HTGceT37RALzTaqwE7HrZhBlNkaa4urgQRV/cEJw='; img-src 'self' data:; connect-src 'self'; base-uri 'self'; object-src 'none'; frame-src 'none'; form-action 'none'; upgrade-insecure-requests;">

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,6 +3,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   {%- include csp.html -%}
+  <style id="antiClickjack">body{display:none !important;}</style>
   <script src="{{ '/assets/js/security.js' | relative_url | escape }}"></script>
   <meta name="referrer" content="strict-origin-when-cross-origin">
   {%- seo -%}

--- a/_layouts/onepager.html
+++ b/_layouts/onepager.html
@@ -6,6 +6,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   {%- include csp.html -%}
+  <style id="antiClickjack">body{display:none !important;}</style>
   <script src="{{ '/assets/js/security.js' | relative_url | escape }}"></script>
   <meta name="referrer" content="strict-origin-when-cross-origin">
   <title>{% if page.title %}{{ page.title | escape }} | {% endif %}{{ site.title | escape }}</title>

--- a/assets/js/security.js
+++ b/assets/js/security.js
@@ -3,33 +3,23 @@
  * Prevents the site from being loaded within an iframe to mitigate Clickjacking attacks.
  * This is necessary because GitHub Pages does not support X-Frame-Options or CSP frame-ancestors headers.
  *
- * IMPROVED DEFENSE:
- * 1. Checks if the window is top-level.
- * 2. If framed, immediately REMOVES all content from the document to prevent the UI from being shown.
- *    This is compatible with strict CSP (no inline styles).
- * 3. Then attempts to bust out (redirect top window).
+ * IMPROVED DEFENSE (OWASP Recommended):
+ * 1. An inline `<style id="antiClickjack">body{display:none !important;}</style>` hides the body by default.
+ * 2. Checks if the window is top-level.
+ * 3. If top-level, removes the style element, revealing the content.
+ * 4. If framed, attempts to bust out (redirect top window). If redirection fails (e.g. sandboxed), content remains hidden.
  */
 (function() {
-  if (window.self !== window.top) {
-      // In a frame!
-
-      // 1. Hide everything immediately by clearing the document.
-      // This prevents the user from seeing or interacting with the framed site.
-      // We assume that if we are framed, we don't want to show anything unless we can successfully bust out.
-      document.documentElement.innerHTML = '';
-
-      // 2. Attempt to bust out
+  if (window.self === window.top) {
+      var antiClickjack = document.getElementById("antiClickjack");
+      if (antiClickjack) {
+          antiClickjack.parentNode.removeChild(antiClickjack);
+      }
+  } else {
       try {
-          // Attempt redirect directly.
-          // Writing to window.top.location is allowed even cross-origin (navigation),
-          // unless blocked by sandbox ('allow-top-navigation').
-          // Reading window.top.location properties (like hostname) throws SecurityError if cross-origin.
-          // So we skip reading and just try to write.
           window.top.location = window.self.location;
       } catch (e) {
-          // If sandbox blocks navigation, we catch the error.
-          // The content remains hidden (removed), so the user is protected.
-          console.warn('Sentinel: Failed to break frame. Site is likely running in a sandboxed iframe. Content removed for protection.');
+          console.warn('Sentinel: Failed to break frame. Site is likely running in a sandboxed iframe. Content remains hidden for protection.');
       }
   }
 })();

--- a/test_style_hide.js
+++ b/test_style_hide.js
@@ -1,0 +1,26 @@
+const { chromium } = require('playwright');
+(async () => {
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+
+  await page.goto('http://localhost:8081/style_hide.html');
+  const h1 = await page.isVisible('h1');
+  console.log('Main page h1 visible:', h1);
+
+  await page.setContent(`
+    <!DOCTYPE html>
+    <html>
+    <body>
+      <iframe sandbox="allow-scripts" src="http://localhost:8081/style_hide.html"></iframe>
+    </body>
+    </html>
+  `);
+
+  await page.waitForTimeout(1000);
+
+  const frame = page.frames()[1];
+  const frame_h1 = await frame.isVisible('h1');
+  console.log('Frame h1 visible (sandboxed):', frame_h1);
+
+  await browser.close();
+})();


### PR DESCRIPTION
🎯 **What:** The existing client-side frame-busting logic in `security.js` attempted to prevent clickjacking by executing JavaScript to clear the document (`document.documentElement.innerHTML = ''`). This logic could be reliably bypassed by an attacker framing the site in a sandboxed iframe without `allow-scripts`, which prevents the script from running and leaves the site fully visible.
⚠️ **Risk:** Attackers could embed the site inside a sandboxed iframe and conduct clickjacking attacks on users without being blocked, potentially leading to unauthorized actions.
🛡️ **Solution:** Implemented the OWASP-recommended frame-busting mechanism. The body is now securely hidden by default using an inline CSS style (`<style id="antiClickjack">body{display:none !important;}</style>`). This inline style is explicitly permitted through the Content Security Policy (CSP) using its exact SHA-256 hash. The `security.js` script was updated to remove this style and reveal the content *only* when it verifies that the window is top-level (`window.self === window.top`). If the script is blocked by sandboxing or fails to navigate, the content safely remains hidden.

---
*PR created automatically by Jules for task [13130073498943853463](https://jules.google.com/task/13130073498943853463) started by @tsainez*