### PR TITLE
🎨 Palette: Improve color contrast of interactive elements (WCAG AA)

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -51,3 +51,7 @@
 ## 2026-06-17 - Empty State Escape Hatches
 **Learning:** When adding an empty state escape hatch to the homepage, linking back to the homepage (`/`) is redundant and circular.
 **Action:** Provide a relevant alternative link, such as the About page (`/about/`), to prevent circular navigation.
+
+## 2026-11-10 - Color Contrast in Themes
+**Learning:** Using a single color variable (like `$focus-color: #82aaff`) for both light and dark modes often leads to accessibility failures (WCAG AA). Colors that look great and have high contrast on dark backgrounds (e.g. #121212) often fail contrast requirements on light backgrounds (e.g. #ffffff).
+**Action:** Define separate semantic color variables for light and dark modes (e.g. `$focus-color` for light mode and `$focus-color-dark` for dark mode). Always test interactive element colors (like buttons, links, and focus rings) against their backgrounds in both color schemes to ensure a minimum contrast ratio of 4.5:1 for text and 3:1 for UI components.

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -4,7 +4,8 @@
 @import "minima";
 
 /* UX Enhancements */
-$focus-color: #82aaff;
+$focus-color: #0056b3;
+$focus-color-dark: #82aaff;
 
 /* Active state for navigation */
 .site-nav .page-link[aria-current="page"] {
@@ -172,13 +173,25 @@ html {
   }
 
   a {
-    color: $focus-color;
+    color: $focus-color-dark;
     &:hover {
-      color: lighten($focus-color, 10%);
+      color: lighten($focus-color-dark, 10%);
     }
     &:focus-visible {
-      outline-color: lighten($focus-color, 10%);
+      outline-color: lighten($focus-color-dark, 10%);
     }
+  }
+
+  .site-nav .nav-trigger:focus-visible + label {
+    outline-color: $focus-color-dark;
+  }
+
+  .reading-progress-bar {
+    background-color: $focus-color-dark;
+  }
+
+  .skip-link:focus-visible {
+    outline-color: $focus-color-dark;
   }
 
   .site-title,
@@ -268,7 +281,7 @@ html {
   /* Mobile/Touch: Always visible (or at least not opacity: 0) */
   opacity: 1;
 
-  &:focus {
+  &:focus-visible {
     opacity: 1;
     outline: 2px solid $focus-color;
     outline-offset: 2px;
@@ -294,6 +307,10 @@ html {
 
     &:hover {
       background-color: rgba(60, 60, 60, 1);
+    }
+
+    &:focus-visible {
+      outline-color: $focus-color-dark;
     }
   }
 }
@@ -444,7 +461,11 @@ h6:hover .anchor-link {
 
     &:hover,
     &:focus {
-      color: lighten($focus-color, 10%);
+      color: lighten($focus-color-dark, 10%);
+    }
+
+    &:focus-visible {
+      outline-color: $focus-color-dark;
     }
 
     &.copied {


### PR DESCRIPTION
- 💡 **What:** Redefined `$focus-color` to `#0056b3` for light mode and preserved the original `#82aaff` as `$focus-color-dark` for dark mode overrides. Also updated the `.copy-code-button` focus state to use `:focus-visible` instead of `:focus`.
- 🎯 **Why:** The original focus color `#82aaff` resulted in a poor contrast ratio (~2.06:1) against the white background in light mode, which fails the WCAG AA contrast requirement of 4.5:1 for text and 3:1 for UI elements like buttons and focus rings. The new color `#0056b3` provides a compliant contrast ratio of ~7.2:1 in light mode.
- ♿ **Accessibility:**
  - Dramatically improves keyboard navigation visibility in light mode due to highly visible focus rings.
  - Improves visibility of the anchor links and the reading progress bar for users with visual impairments.
  - Improves visual feedback of the "copy code" button by preventing sticky focus rings on mouse click using `:focus-visible`.
- Documented findings in `.jules/palette.md`

---
*PR created automatically by Jules for task [8741523495045576694](https://jules.google.com/task/8741523495045576694) started by @tsainez*